### PR TITLE
[Refactor] Upload KMS encrypted userdata to S3, to limit userdata access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 coverage.out
 coverage.html
 vendor
+odin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang@sha256:62b42efa7bbd7efe429c43e4a1901f26fe3728b4603cb802248fff0a898b4825
+
+# Install Zip
+RUN apt-get update && apt-get upgrade -y && apt-get install -y zip
+
+# Install Dep
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+WORKDIR /go/src/github.com/coinbase/odin
+
+COPY Gopkg.lock Gopkg.toml ./
+
+RUN dep ensure -vendor-only
+
+COPY . .
+
+RUN go build && go install
+
+# builds lambda.zip
+RUN ./scripts/build_lambda_zip
+RUN shasum -a 256 lambda.zip | awk '{print $1}' > lambda.zip.sha256
+
+RUN mv lambda.zip.sha256 lambda.zip /
+RUN odin json > /state_machine.json
+
+CMD ["odin"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,8 +8,8 @@
     "lambda/messages",
     "lambdacontext"
   ]
-  revision = "fafa7e49388b8991caf99308e80655ba91816b72"
-  version = "v1.1.0"
+  revision = "4d30d0ff60440c2d0480a15747c96ee71c3c53d4"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -25,6 +25,7 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
@@ -36,6 +37,8 @@
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
     "private/protocol/query",
@@ -66,8 +69,8 @@
     "service/sns/snsiface",
     "service/sts"
   ]
-  revision = "31bd69f7db00cbf3d85d129e16d42304cb6e455f"
-  version = "v1.13.44"
+  revision = "f0bbc646e13bfc451409e960cf33239aabb8671a"
+  version = "v1.14.9"
 
 [[projects]]
   branch = "master"
@@ -85,7 +88,7 @@
     "utils/run",
     "utils/to"
   ]
-  revision = "54e9ef1a9c5354f0a284a4f6d507788aaf57824a"
+  revision = "c7e6c098dc5d3f42893720b82601dda2081355b0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -96,8 +99,8 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
-  version = "v1.36.0"
+  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
+  version = "v1.37.0"
 
 [[projects]]
   branch = "master"
@@ -119,12 +122,12 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "aac4ffe3489484a6372c99e6c931ad04d6313a9c4a61be765c4bc6fcbca9ec49"
+  inputs-digest = "1537a11819514b3b7aa16690dd46ee88968a0f83728326609e33e6ed9074bc9d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,33 +1,6 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
-
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.13.32"
+  version = "1.14.9"
 
 [[constraint]]
   branch = "master"
@@ -39,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.2.2"
 
 [prune]
   go-tests = true

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -96,7 +96,7 @@ func FetchASGTag(tags []*autoscaling.TagDescription, tagKey *string) *string {
 	return nil
 }
 
-// HasDefaultValue
+// HasAllValue checks for the _all value tag
 func HasAllValue(tag *string) bool {
 	if tag == nil {
 		return false
@@ -188,15 +188,6 @@ type Clients interface {
 type ClientsStr struct {
 	session *session.Session
 	configs map[string]*aws.Config
-
-	S3  S3API
-	ASG ASGAPI
-	ELB ELBAPI
-	EC2 EC2API
-	ALB ALBAPI
-	CW  CWAPI
-	IAM IAMAPI
-	SNS SNSAPI
 }
 
 // GetSession get session

--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -62,6 +62,7 @@ func MakeMockASG(name string, projetName string, configName string, serviceName 
 	}
 }
 
+// MakeMockASGInstances returns
 func MakeMockASGInstances(healthy int, unhealthy int, terming int) []*autoscaling.Instance {
 	ins := []*autoscaling.Instance{}
 	x := 0

--- a/deployer/client/client_test.go
+++ b/deployer/client/client_test.go
@@ -19,7 +19,6 @@ func minimalRelease(t *testing.T) *models.Release {
     "config_name": "config",
     "ami": "ami-123456",
     "subnets": ["subnet-1"],
-    "user_data": "echo DATE",
     "services": {
       "web": {
         "instance_type": "t2.small",
@@ -31,42 +30,6 @@ func minimalRelease(t *testing.T) *models.Release {
 
 	assert.NoError(t, err)
 	return &r
-}
-
-func Test_releaseFromFileOrJSON(t *testing.T) {
-	release, err := releaseFromFileOrJSON(to.Strp(` {
-    "release_id": "rr",
-    "project_name": "project",
-    "config_name": "config",
-    "ami": "ami-123456",
-    "subnets": ["subnet-1"],
-    "user_data": "echo DATE",
-    "services": {
-      "web": {
-        "instance_type": "t2.small",
-        "security_groups": ["web-sg"]
-      }
-    }
-  }`), to.Strp("region"), to.Strp("account"))
-	assert.NoError(t, err)
-
-	assert.Equal(t, "rr", *release.ReleaseID)
-	assert.Equal(t, "project", *release.ProjectName)
-}
-
-func Test_releaseFromFileOrJSON_badRelease(t *testing.T) {
-	_, err := releaseFromFileOrJSON(to.Strp(`{}`), to.Strp("region"), to.Strp("account"))
-	assert.Error(t, err)
-}
-
-func Test_releaseFromFileOrJSON_badJSON(t *testing.T) {
-	_, err := releaseFromFileOrJSON(to.Strp(`{`), to.Strp("region"), to.Strp("account"))
-	assert.Error(t, err)
-}
-
-func Test_releaseFromFileOrJSON_UnknownKey(t *testing.T) {
-	_, err := releaseFromFileOrJSON(to.Strp(`{"bad_key": "val"}`), to.Strp("region"), to.Strp("account"))
-	assert.Error(t, err)
 }
 
 func createStateDetails(release *models.Release, tn string) *execution.StateDetails {

--- a/deployer/client/deploy_test.go
+++ b/deployer/client/deploy_test.go
@@ -12,6 +12,7 @@ func Test_Deploy(t *testing.T) {
 	awsc := mocks.MockAWS()
 	r := minimalRelease(t)
 	r.SetDefaultRegionAccount(to.Strp("region"), to.Strp("accountid"))
+	r.SetUserData(to.Strp("#cloud_config"))
 
 	err := deploy(awsc, r, to.Strp("deployerARN"))
 	assert.NoError(t, err)

--- a/deployer/client/halt.go
+++ b/deployer/client/halt.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Halt attempts to halt release
-func Halt(fileOrJSON *string) error {
+func Halt(releaseFile *string) error {
 	region, accountID := to.RegionAccount()
-	release, err := releaseFromFileOrJSON(fileOrJSON, region, accountID)
+	release, err := releaseFromFile(releaseFile, region, accountID)
 	if err != nil {
 		return err
 	}

--- a/deployer/handlers_test.go
+++ b/deployer/handlers_test.go
@@ -21,7 +21,7 @@ func Test_ValidateResources_FetchesCorrectResources(t *testing.T) {
 	assert.NoError(t, err)
 	res := rel.Services["web"].Resources
 	assert.Equal(t, "ami-123456", *res.Image)
-	assert.Equal(t, "/project/config/web/web-profile", *res.Profile)
+	assert.Equal(t, "/odin/project/config/web/web-profile", *res.Profile)
 	assert.Equal(t, "project-config-web-old-release", *res.PrevASG)
 	assert.Equal(t, []string{"group-id"}, to.StrSlice(res.SecurityGroups))
 	assert.Equal(t, []string{"web-elb"}, to.StrSlice(res.ELBs))

--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -77,7 +77,7 @@ func StateMachine() (*machine.StateMachine, error) {
           },
           {
             "Comment": "Try to Release Locks",
-            "ErrorEquals": ["HaltError"],
+            "ErrorEquals": ["HaltError", "BadReleaseError"],
             "ResultPath": "$.error",
             "Next": "ReleaseLockFailure"
           }

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -41,7 +41,7 @@ func MockAwsClients(release *Release) *mocks.MockClients {
 		awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
 		awsc.ALB.AddTargetGroup("web-elb-target", *release.ProjectName, *release.ConfigName, "web")
 
-		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/%v/%v/web/", *release.ProjectName, *release.ConfigName))
+		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
 		awsc.IAM.AddGetRole("sns_role")
 
 		// Upload items to S3

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -20,6 +20,11 @@ func MockPrepareRelease(release *Release) {
 	release.SetDefaultRegionAccount(to.Strp("region"), to.Strp("account"))
 	release.SetDefaults()
 	release.SetUUID()
+	if release.UserData() == nil {
+		release.SetUserData(to.Strp("#cloud_config"))
+	}
+
+	release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
 }
 
 // MockAwsClients mocks
@@ -39,10 +44,20 @@ func MockAwsClients(release *Release) *mocks.MockClients {
 		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/%v/%v/web/", *release.ProjectName, *release.ConfigName))
 		awsc.IAM.AddGetRole("sns_role")
 
-		if release.ReleaseID != nil {
-			raw, _ := json.Marshal(release)
-			awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
+		// Upload items to S3
+		if release.ReleaseID == nil {
+			release.ReleaseID = to.Strp("rr")
 		}
+
+		if release.UserData() == nil {
+			release.SetUserData(to.Strp("#cloud_config"))
+		}
+
+		awsc.S3.AddGetObject(*release.UserDataPath(), *release.UserData(), nil)
+		release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+
+		raw, _ := json.Marshal(release)
+		awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
 	}
 
 	return awsc
@@ -63,7 +78,6 @@ func MockMinimalRelease(t *testing.T) *Release {
     "config_name": "config",
     "ami": "ami-123456",
     "subnets": ["subnet-1"],
-    "user_data": "echo DATE",
     "services": {
       "web": {
         "instance_type": "t2.small",
@@ -92,7 +106,6 @@ func MockRelease(t *testing.T) *Release {
     "ami": "ubuntu",
     "subnets": ["private-subnet"],
     "timeout": 1,
-    "user_data": "echo DATE",
     "lifecycle": {
       "TermHook" : {
         "transition": "autoscaling:EC2_INSTANCE_TERMINATING",

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -264,7 +264,7 @@ func (release *Release) ValidateReleaseSHA(s3c aws.S3API) error {
 	return nil
 }
 
-// Validates the userdata has the correct SHA for the release
+// ValidateUserDataSHA validates the userdata has the correct SHA for the release
 func (release *Release) ValidateUserDataSHA(s3c aws.S3API) error {
 	err := release.DownloadUserData(s3c)
 

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -33,13 +33,15 @@ type Release struct {
 	Timeout *int      `json:"timeout,omitempty"` // How long should we try and deploy in seconds
 
 	CreatedAt     *time.Time `json:"created_at,omitempty"`
-	ReleaseSHA256 string     `json:"release_sha256"` // Not Set By Client
+	releaseSHA256 string
 
 	Success *bool `json:"success,omitempty"`
 
 	Image *string `json:"ami,omitempty"`
 
-	UserData *string `json:"user_data,omitempty"`
+	userdata       *string // Not serialized
+	UserDataSHA256 *string `json:"user_data_sha256,omitempty"`
+	UserDataKMSKey *string `json:"user_data_kms_key,omitempty"`
 
 	// LifeCycleHooks
 	LifeCycleHooks map[string]*LifeCycleHook `json:"lifecycle,omitempty"`
@@ -81,6 +83,12 @@ func (release *Release) ReleasePath() *string {
 	return &s
 }
 
+// UserDataPath returns
+func (release *Release) UserDataPath() *string {
+	s := fmt.Sprintf("%v/%v/userdata", release.rootPath(), *release.ReleaseID)
+	return &s
+}
+
 func (release *Release) errorPrefix() string {
 	if release.ReleaseID == nil {
 		return fmt.Sprintf("Release Error:")
@@ -113,6 +121,23 @@ func (release *Release) SetDefaultRegionAccount(region *string, account *string)
 	}
 }
 
+// SetDefaultsWithUserData sets the default values including userdata fetched from S3
+func (release *Release) SetDefaultsWithUserData(s3c aws.S3API) error {
+	release.SetDefaults()
+	err := release.DownloadUserData(s3c)
+	if err != nil {
+		return err
+	}
+
+	for _, service := range release.Services {
+		if service != nil {
+			service.SetUserData(release.UserData())
+		}
+	}
+
+	return nil
+}
+
 // SetDefaults assigns default values
 func (release *Release) SetDefaults() {
 	if release.Timeout == nil {
@@ -122,6 +147,8 @@ func (release *Release) SetDefaults() {
 	if release.Healthy == nil {
 		release.Healthy = to.Boolp(false)
 	}
+
+	release.SetDefaultKMSKey()
 
 	for name, lc := range release.LifeCycleHooks {
 		if lc != nil {
@@ -136,6 +163,14 @@ func (release *Release) SetDefaults() {
 	}
 }
 
+// SetDefaultKMSKey sets the default KMS key to be used
+func (release *Release) SetDefaultKMSKey() {
+	if release.UserDataKMSKey == nil {
+		// Default alias to the default s3 KMS key
+		release.UserDataKMSKey = to.Strp("alias/aws/s3")
+	}
+}
+
 //////////
 // Validate
 //////////
@@ -147,6 +182,10 @@ func (release *Release) Validate(s3c aws.S3API) error {
 	}
 
 	if err := release.ValidateReleaseSHA(s3c); err != nil {
+		return fmt.Errorf("%v %v", release.errorPrefix(), err.Error())
+	}
+
+	if err := release.ValidateUserDataSHA(s3c); err != nil {
 		return fmt.Errorf("%v %v", release.errorPrefix(), err.Error())
 	}
 
@@ -184,16 +223,16 @@ func (release *Release) ValidateAttributes() error {
 		return fmt.Errorf("AwsAccountID must be defined")
 	}
 
+	if is.EmptyStr(release.UserDataSHA256) {
+		return fmt.Errorf("UserDataSHA256 must be defined")
+	}
+
 	if is.EmptyStr(release.ReleaseID) {
 		return fmt.Errorf("ReleaseID must be defined")
 	}
 
 	if is.EmptyStr(release.Bucket) {
 		return fmt.Errorf("Bucket must be defined")
-	}
-
-	if is.EmptyStr(release.UserData) {
-		return fmt.Errorf("UserData must be defined")
 	}
 
 	if release.CreatedAt == nil {
@@ -218,11 +257,54 @@ func (release *Release) ValidateReleaseSHA(s3c aws.S3API) error {
 
 	expected := to.SHA256Struct(s3Release)
 
-	if expected != release.ReleaseSHA256 {
-		return fmt.Errorf("Release SHA incorrect expected %v, got %v", expected, release.ReleaseSHA256)
+	if expected != release.releaseSHA256 {
+		return fmt.Errorf("Release SHA incorrect expected %v, got %v", expected, release.releaseSHA256)
 	}
 
 	return nil
+}
+
+// Validates the userdata has the correct SHA for the release
+func (release *Release) ValidateUserDataSHA(s3c aws.S3API) error {
+	err := release.DownloadUserData(s3c)
+
+	if err != nil {
+		return fmt.Errorf("Error Getting UserData with %v", err.Error())
+	}
+
+	userdataSha := to.SHA256Str(release.UserData())
+	if userdataSha != *release.UserDataSHA256 {
+		return fmt.Errorf("UserData SHA incorrect expected %v, got %v", userdataSha, *release.UserDataSHA256)
+	}
+
+	return nil
+}
+
+// UserData returns user data
+func (release *Release) UserData() *string {
+	return release.userdata
+}
+
+// DownloadUserData fetches and populates the User data from S3
+func (release *Release) DownloadUserData(s3c aws.S3API) error {
+	userdataBytes, err := s3.Get(s3c, release.Bucket, release.UserDataPath())
+
+	if err != nil {
+		return err
+	}
+
+	release.SetUserData(to.Strp(string(*userdataBytes)))
+	return nil
+}
+
+// SetUserData sets the User data
+func (release *Release) SetUserData(userdata *string) {
+	release.userdata = userdata
+}
+
+// SetReleaseSHA256 sets the release SHA
+func (release *Release) SetReleaseSHA256(sha string) {
+	release.releaseSHA256 = sha
 }
 
 // ValidateServices returns

--- a/deployer/models/release_test.go
+++ b/deployer/models/release_test.go
@@ -10,7 +10,7 @@ import (
 func Test_Release_Validate_Works(t *testing.T) {
 	r := MockRelease(t)
 	awsc := MockAwsClients(r)
-	r.ReleaseSHA256 = to.SHA256Struct(r)
+	r.releaseSHA256 = to.SHA256Struct(r)
 
 	MockPrepareRelease(r)
 
@@ -27,7 +27,7 @@ func Test_Release_ValidateAttributes_Works(t *testing.T) {
 func Test_Release_ValidateReleaseSHA_Works(t *testing.T) {
 	r := MockRelease(t)
 	awsc := MockAwsClients(r)
-	r.ReleaseSHA256 = to.SHA256Struct(r)
+	r.releaseSHA256 = to.SHA256Struct(r)
 
 	MockPrepareRelease(r)
 

--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -33,7 +33,8 @@ type HealthReport struct {
 
 // Service struct
 type Service struct {
-	release *Release
+	release  *Release
+	userdata *string
 
 	// Generated
 	ServiceName *string `json:"service_name,omitempty"`
@@ -95,10 +96,12 @@ func (service *Service) ReleaseID() *string {
 	return service.release.ReleaseID
 }
 
+// CreatedAt returns created at data
 func (service *Service) CreatedAt() *time.Time {
 	return service.release.CreatedAt
 }
 
+// ServiceID returns a formatted string of the services ID
 func (service *Service) ServiceID() *string {
 	if service.ProjectName() == nil || service.ConfigName() == nil || service.ServiceName == nil || service.CreatedAt() == nil {
 		return nil
@@ -117,12 +120,18 @@ func (service *Service) Subnets() []*string {
 func (service *Service) UserData() *string {
 	templateARGs := []string{}
 	templateARGs = append(templateARGs, "{{RELEASE_ID}}", to.Strs(service.ReleaseID()))
-	templateARGs = append(templateARGs, "{{SERVICE_NAME}}", to.Strs(service.ServiceName))
 	templateARGs = append(templateARGs, "{{PROJECT_NAME}}", to.Strs(service.ProjectName()))
 	templateARGs = append(templateARGs, "{{CONFIG_NAME}}", to.Strs(service.ConfigName()))
+	templateARGs = append(templateARGs, "{{SERVICE_NAME}}", to.Strs(service.ServiceName))
+
 	replacer := strings.NewReplacer(templateARGs...)
 
-	return to.Strp(replacer.Replace(to.Strs(service.release.UserData)))
+	return to.Strp(replacer.Replace(to.Strs(service.userdata)))
+}
+
+// SetUserData sets the userdata
+func (service *Service) SetUserData(userdata *string) {
+	service.userdata = userdata
 }
 
 // LifeCycleHooks returns

--- a/deployer/models/service_resources.go
+++ b/deployer/models/service_resources.go
@@ -267,12 +267,13 @@ func ValidateIAMProfile(service serviceIface, profile *iam.Profile) error {
 	}
 
 	// This allows for default profiles for all services || all configs || all projects
-	specificPath := fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), *service.ConfigName(), *service.Name())
+	pathFormat := "/odin/%v/%v/%v/"
+	specificPath := fmt.Sprintf(pathFormat, *service.ProjectName(), *service.ConfigName(), *service.Name())
 	validPaths := []string{
 		specificPath,
-		fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), *service.ConfigName(), "_all"),
-		fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), "_all", "_all"),
-		fmt.Sprintf("/%v/%v/%v/", "_all", "_all", "_all"),
+		fmt.Sprintf(pathFormat, *service.ProjectName(), *service.ConfigName(), "_all"),
+		fmt.Sprintf(pathFormat, *service.ProjectName(), "_all", "_all"),
+		fmt.Sprintf(pathFormat, "_all", "_all", "_all"),
 	}
 
 	for _, validPath := range validPaths {

--- a/deployer/models/service_resources.go
+++ b/deployer/models/service_resources.go
@@ -266,13 +266,23 @@ func ValidateIAMProfile(service serviceIface, profile *iam.Profile) error {
 		return fmt.Errorf("Iam Profile Path not found")
 	}
 
-	validPath := fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), *service.ConfigName(), *service.Name())
-	if *profile.Path != validPath {
-		// Again should never happen
-		return fmt.Errorf("Iam Profile Path incorrect, it is %q and requires %q", *profile.Path, validPath)
+	// This allows for default profiles for all services || all configs || all projects
+	specificPath := fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), *service.ConfigName(), *service.Name())
+	validPaths := []string{
+		specificPath,
+		fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), *service.ConfigName(), "_all"),
+		fmt.Sprintf("/%v/%v/%v/", *service.ProjectName(), "_all", "_all"),
+		fmt.Sprintf("/%v/%v/%v/", "_all", "_all", "_all"),
 	}
 
-	return nil
+	for _, validPath := range validPaths {
+		if *profile.Path == validPath {
+			return nil
+		}
+	}
+
+	// Again should never happen
+	return fmt.Errorf("Iam Profile Path incorrect, it is %q and requires %q", *profile.Path, specificPath)
 }
 
 // ValidateSecurityGroup returns

--- a/deployer/models/service_resources_test.go
+++ b/deployer/models/service_resources_test.go
@@ -98,7 +98,23 @@ func Test_Service_ValidateIAMProfile(t *testing.T) {
 	assert.Error(t, ValidateIAMProfile(&MockService{}, &iam.Profile{}))
 
 	assert.NoError(t, ValidateIAMProfile(&MockService{}, &iam.Profile{
-		Path: to.Strp("/project/config/servicename/"),
+		Path: to.Strp("/odin/project/config/servicename/"),
+	}))
+
+	assert.NoError(t, ValidateIAMProfile(&MockService{}, &iam.Profile{
+		Path: to.Strp("/odin/project/config/_all/"),
+	}))
+
+	assert.NoError(t, ValidateIAMProfile(&MockService{}, &iam.Profile{
+		Path: to.Strp("/odin/project/_all/_all/"),
+	}))
+
+	assert.NoError(t, ValidateIAMProfile(&MockService{}, &iam.Profile{
+		Path: to.Strp("/odin/_all/_all/_all/"),
+	}))
+
+	assert.Error(t, ValidateIAMProfile(&MockService{}, &iam.Profile{
+		Path: to.Strp("/notodin/_all/_all/_all/"),
 	}))
 }
 

--- a/deployer/models/service_test.go
+++ b/deployer/models/service_test.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coinbase/step/utils/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Service_SetGetUserdata(t *testing.T) {
+	release := MockMinimalRelease(t)
+
+	service := Service{}
+	service.SetUserData(to.Strp("{{RELEASE_ID}}\n{{PROJECT_NAME}}\n{{CONFIG_NAME}}\n{{SERVICE_NAME}}\n"))
+	service.SetDefaults(release, "web")
+
+	assert.Equal(t, fmt.Sprintf("%v\n%v\n%v\nweb\n", *release.ReleaseID, *release.ProjectName, *release.ConfigName), *service.UserData())
+}

--- a/odin.go
+++ b/odin.go
@@ -30,7 +30,7 @@ func main() {
 		run.JSON(deployer.StateMachine())
 	case "deploy":
 		// Send Configuration to the deployer
-		// arg is a filename OR a JSON string
+		// arg is a filename
 		err := client.Deploy(&arg)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -48,6 +48,6 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println("Usage: odin <json|exec|deploy> <arg> (No args starts Lambda)")
+	fmt.Println("Usage: odin <json|deploy|halt> <release_file> (No args starts Lambda)")
 	os.Exit(0)
 }

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -15,7 +15,6 @@
       "heartbeat_timeout": 300
     }
   },
-  "user_data": "{{USER_DATA_FILE}}",
   "services": {
     "worker": {
       "instance_type": "t2.nano",

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -18,7 +18,8 @@
   "services": {
     "worker": {
       "instance_type": "t2.nano",
-      "security_groups": ["ec2::default"]
+      "security_groups": ["ec2::default"],
+      "profile": "default-profile"
     },
     "web": {
       "instance_type": "t2.nano",

--- a/releases/null-release.json
+++ b/releases/null-release.json
@@ -3,7 +3,6 @@
   "config_name": "development",
   "subnets": ["test_private_subnet_a"],
   "ami": "ubuntu",
-  "user_data": "#cloud-config",
   "services": {
     "null": {
       "instance_type": "t2.nano",

--- a/releases/null-release.json.userdata
+++ b/releases/null-release.json.userdata
@@ -1,0 +1,1 @@
+#cloud_config

--- a/resources/deploy-test-resources.rb
+++ b/resources/deploy-test-resources.rb
@@ -162,10 +162,10 @@ project.resource("aws_alb_listener", 'alb_ln') {
   }
 }
 
-# Instance Role
+# Instance Roles
 role = project.resource('aws_iam_role', 'coinbase-deploy-test-dns') {
   name 'coinbase-deploy-test'
-  path '/coinbase/deploy-test/development/web/'
+  path '/odin/coinbase/deploy-test/development/web/'
   assume_role_policy(%({
     "Version": "2012-10-17",
     "Statement": [
@@ -180,7 +180,37 @@ role = project.resource('aws_iam_role', 'coinbase-deploy-test-dns') {
   }))
 }
 
-policy = project.resource('aws_iam_policy', 'coinbase-deploy-test') {
+project.resource('aws_iam_instance_profile', 'coinbase-deploy-test') {
+  name 'coinbase-deploy-test'
+  path '/odin/coinbase/deploy-test/development/web/'
+  role role
+}
+
+
+default_role = project.resource('aws_iam_role', 'default-profile') {
+  name 'default-profile'
+  path '/odin/_all/_all/_all/'
+  assume_role_policy(%({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ec2.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }))
+}
+
+project.resource('aws_iam_instance_profile', 'default-profile') {
+  name 'default-profile'
+  path '/odin/_all/_all/_all/'
+  role default_role
+}
+
+policy = project.resource('aws_iam_policy', 'az-policy') {
   name 'coinbase-deploy-test'
   policy '{
               "Version": "2012-10-17",
@@ -196,14 +226,8 @@ policy = project.resource('aws_iam_policy', 'coinbase-deploy-test') {
             }'
 }
 
-project.resource('aws_iam_policy_attachment', 'coinbase-deploy-test') {
-  name 'coinbase-deploy-test'
+project.resource('aws_iam_policy_attachment', 'default-profile') {
+  name 'default-profile'
   _policy policy
-  roles [role]
-}
-
-project.resource('aws_iam_instance_profile', 'coinbase-deploy-test') {
-  name 'coinbase-deploy-test'
-  path '/coinbase/deploy-test/development/web/'
-  role role
+  roles [role, default_role]
 }


### PR DESCRIPTION
Also:

1. expanded the ability for the different paths an instance profile an have, to allow for default and per project and per config profiles. This should make it easier to use and develop with Odin.
2. deploy only with files now since userdata is no longer in the release
3. adding `odin` prefix to roles so that external services can directly reference roles assigned by odin. 