### PR TITLE
[Refactor] no need to send kms keys to odin

### DIFF
--- a/aws/alb/target_group.go
+++ b/aws/alb/target_group.go
@@ -10,10 +10,11 @@ import (
 
 // TargetGroup struct
 type TargetGroup struct {
-	ProjectNameTag *string
-	ConfigNameTag  *string
-	ServiceNameTag *string
-	TargetGroupArn *string
+	ProjectNameTag  *string
+	ConfigNameTag   *string
+	ServiceNameTag  *string
+	TargetGroupArn  *string
+	TargetGroupName *string
 }
 
 // ProjectName returns tag
@@ -29,6 +30,10 @@ func (s *TargetGroup) ConfigName() *string {
 // ServiceName returns tag
 func (s *TargetGroup) ServiceName() *string {
 	return s.ServiceNameTag
+}
+
+func (s *TargetGroup) Name() *string {
+	return s.TargetGroupName
 }
 
 //////
@@ -93,10 +98,11 @@ func find(alb aws.ALBAPI, targetGroupName *string) (*TargetGroup, error) {
 	}
 
 	return &TargetGroup{
-		ProjectNameTag: aws.FetchELBV2Tag(awsTags, to.Strp("ProjectName")),
-		ConfigNameTag:  aws.FetchELBV2Tag(awsTags, to.Strp("ConfigName")),
-		ServiceNameTag: aws.FetchELBV2Tag(awsTags, to.Strp("ServiceName")),
-		TargetGroupArn: awsTarget.TargetGroupArn,
+		ProjectNameTag:  aws.FetchELBV2Tag(awsTags, to.Strp("ProjectName")),
+		ConfigNameTag:   aws.FetchELBV2Tag(awsTags, to.Strp("ConfigName")),
+		ServiceNameTag:  aws.FetchELBV2Tag(awsTags, to.Strp("ServiceName")),
+		TargetGroupArn:  awsTarget.TargetGroupArn,
+		TargetGroupName: targetGroupName,
 	}, nil
 }
 

--- a/aws/ami/image.go
+++ b/aws/ami/image.go
@@ -37,11 +37,7 @@ func findByID(ec2c aws.EC2API, id *string) (*Image, error) {
 func findByTag(ec2c aws.EC2API, nameTag *string) (*Image, error) {
 	filters := []*ec2.Filter{
 		&ec2.Filter{
-			Name:   to.Strp("tag-key"),
-			Values: []*string{to.Strp("Name")},
-		},
-		&ec2.Filter{
-			Name:   to.Strp("tag-value"),
+			Name:   to.Strp("tag:Name"),
 			Values: []*string{nameTag},
 		},
 	}

--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/coinbase/odin/aws"
 	"github.com/coinbase/odin/aws/lc"
+	"github.com/coinbase/step/utils/is"
 	"github.com/coinbase/step/utils/to"
 )
 
@@ -16,6 +17,7 @@ type ASG struct {
 	ConfigNameTag  *string
 	ServiceNameTag *string
 	ReleaseIDTag   *string
+	ReleaseIdTag   *string
 
 	DesiredCapacity *int64
 
@@ -45,7 +47,10 @@ func (s *ASG) ServiceName() *string {
 
 // ReleaseID returns tag
 func (s *ASG) ReleaseID() *string {
-	return s.ReleaseIDTag
+	if !is.EmptyStr(s.ReleaseIDTag) {
+		return s.ReleaseIDTag
+	}
+	return s.ReleaseIdTag
 }
 
 // ServiceID returns tag
@@ -64,6 +69,7 @@ func newASG(group *autoscaling.Group) *ASG {
 		ConfigNameTag:  aws.FetchASGTag(group.Tags, to.Strp("ConfigName")),
 		ServiceNameTag: aws.FetchASGTag(group.Tags, to.Strp("ServiceName")),
 		ReleaseIDTag:   aws.FetchASGTag(group.Tags, to.Strp("ReleaseID")),
+		ReleaseIdTag:   aws.FetchASGTag(group.Tags, to.Strp("ReleaseId")),
 
 		AutoScalingGroupName:    group.AutoScalingGroupName,
 		LaunchConfigurationName: group.LaunchConfigurationName,

--- a/aws/elb/elb.go
+++ b/aws/elb/elb.go
@@ -32,6 +32,10 @@ func (s *LoadBalancer) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+func (s *LoadBalancer) Name() *string {
+	return s.LoadBalancerName
+}
+
 ///////
 // Healthy
 ///////

--- a/aws/mocks/mock_ec2.go
+++ b/aws/mocks/mock_ec2.go
@@ -90,7 +90,7 @@ func (m *EC2Client) AddSubnet(nameTag string, id string) {
 // DescribeSecurityGroups returns
 func (m *EC2Client) DescribeSecurityGroups(in *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
 	m.init()
-	sgName := in.Filters[1].Values[0]
+	sgName := in.Filters[0].Values[0]
 	resp := m.DescribeSecurityGroupsResp[*sgName]
 	if resp == nil {
 		return &ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{}}, nil

--- a/aws/mocks/mock_ec2.go
+++ b/aws/mocks/mock_ec2.go
@@ -46,7 +46,7 @@ func (m *EC2Client) AddSecurityGroup(name string, projectName string, configName
 	m.DescribeSecurityGroupsResp[name] = &DescribeSecurityGroupsResponse{
 		Resp: &ec2.DescribeSecurityGroupsOutput{
 			SecurityGroups: []*ec2.SecurityGroup{
-				MakeMockSecurityGroup(projectName, configName, serviceName),
+				MakeMockSecurityGroup(name, projectName, configName, serviceName),
 			},
 		},
 		Error: err,
@@ -99,10 +99,11 @@ func (m *EC2Client) DescribeSecurityGroups(in *ec2.DescribeSecurityGroupsInput) 
 }
 
 // MakeMockSecurityGroup returns
-func MakeMockSecurityGroup(projectName string, configName string, serviceName string) *ec2.SecurityGroup {
+func MakeMockSecurityGroup(name string, projectName string, configName string, serviceName string) *ec2.SecurityGroup {
 	return &ec2.SecurityGroup{
 		GroupId: to.Strp("group-id"),
 		Tags: []*ec2.Tag{
+			&ec2.Tag{Key: to.Strp("Name"), Value: to.Strp(name)},
 			&ec2.Tag{Key: to.Strp("ProjectName"), Value: to.Strp(projectName)},
 			&ec2.Tag{Key: to.Strp("ConfigName"), Value: to.Strp(configName)},
 			&ec2.Tag{Key: to.Strp("ServiceName"), Value: to.Strp(serviceName)},

--- a/aws/sg/security_group.go
+++ b/aws/sg/security_group.go
@@ -36,11 +36,7 @@ func (s *SecurityGroup) ServiceName() *string {
 func Find(ec2Client aws.EC2API, nameTags []*string) ([]*SecurityGroup, error) {
 	filters := []*ec2.Filter{
 		&ec2.Filter{
-			Name:   to.Strp("tag-key"),
-			Values: []*string{to.Strp("Name")},
-		},
-		&ec2.Filter{
-			Name:   to.Strp("tag-value"),
+			Name:   to.Strp("tag:Name"),
 			Values: nameTags,
 		},
 	}
@@ -55,6 +51,8 @@ func Find(ec2Client aws.EC2API, nameTags []*string) ([]*SecurityGroup, error) {
 	}
 
 	sgs := newSGs(output.SecurityGroups)
+
+	fmt.Println(sgs)
 
 	// Need to validate that each Name tag matches Exactly one Security Group
 	for _, nameTag := range nameTags {

--- a/aws/sg/security_group.go
+++ b/aws/sg/security_group.go
@@ -32,6 +32,10 @@ func (s *SecurityGroup) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+func (s *SecurityGroup) Name() *string {
+	return s.NameTag
+}
+
 // Find returns the security groups with tags
 func Find(ec2Client aws.EC2API, nameTags []*string) ([]*SecurityGroup, error) {
 	output, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{

--- a/aws/subnet/subnets.go
+++ b/aws/subnet/subnets.go
@@ -74,11 +74,7 @@ func findByID(ec2Client aws.EC2API, ids []*string) ([]*Subnet, error) {
 func findByTag(ec2Client aws.EC2API, nameTags []*string) ([]*Subnet, error) {
 	filters := []*ec2.Filter{
 		&ec2.Filter{
-			Name:   to.Strp("tag-key"),
-			Values: []*string{to.Strp("Name")},
-		},
-		&ec2.Filter{
-			Name:   to.Strp("tag-value"),
+			Name:   to.Strp("tag:Name"),
 			Values: nameTags,
 		},
 	}

--- a/deployer/client/client.go
+++ b/deployer/client/client.go
@@ -50,7 +50,6 @@ func validateClientAttributes(release *models.Release) error {
 
 func prepareRelease(release *models.Release, region *string, accountID *string) {
 	release.SetDefaultRegionAccount(region, accountID)
-	release.SetDefaultKMSKey()
 
 	release.ReleaseID = to.TimeUUID("release-")
 	release.CreatedAt = to.Timep(time.Now())

--- a/deployer/client/deploy.go
+++ b/deployer/client/deploy.go
@@ -12,14 +12,14 @@ import (
 )
 
 // Deploy attempts to deploy release
-func Deploy(releaseFile *string) error {
+func Deploy(step_fn *string, releaseFile *string) error {
 	region, accountID := to.RegionAccount()
 	release, err := releaseFromFile(releaseFile, region, accountID)
 	if err != nil {
 		return err
 	}
 
-	deployerARN := to.StepArn(region, accountID, to.Strp("coinbase-odin"))
+	deployerARN := to.StepArn(region, accountID, step_fn)
 
 	return deploy(&aws.ClientsStr{}, release, deployerARN)
 }

--- a/deployer/client/halt.go
+++ b/deployer/client/halt.go
@@ -10,14 +10,14 @@ import (
 )
 
 // Halt attempts to halt release
-func Halt(releaseFile *string) error {
+func Halt(step_fn *string, releaseFile *string) error {
 	region, accountID := to.RegionAccount()
 	release, err := releaseFromFile(releaseFile, region, accountID)
 	if err != nil {
 		return err
 	}
 
-	deployerARN := to.StepArn(region, accountID, to.Strp("coinbase-odin"))
+	deployerARN := to.StepArn(region, accountID, step_fn)
 
 	return halt(&aws.ClientsStr{}, release, deployerARN)
 }

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -100,6 +100,10 @@ func Lock(awsc aws.Clients) DeployHandler {
 
 		// Check grabbed first because there are errors that can be thrown before anything is created
 		if !grabbed {
+			if err != nil {
+				return nil, throw(&LockExistsError{&ErrorWrapper{err}})
+			}
+
 			return nil, throw(&LockExistsError{&ErrorWrapper{fmt.Errorf("Lock Already Exists")}})
 		}
 

--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -222,15 +222,15 @@ func TaskFunctions() *handler.TaskFunctions {
 }
 
 // CreateTaskFunctinons returns
-func CreateTaskFunctinons(awsClients aws.Clients) *handler.TaskFunctions {
+func CreateTaskFunctinons(awsc aws.Clients) *handler.TaskFunctions {
 	tm := handler.TaskFunctions{}
-	tm["Validate"] = Validate(awsClients)
-	tm["Lock"] = Lock(awsClients)
-	tm["ValidateResources"] = ValidateResources(awsClients)
-	tm["Deploy"] = Deploy(awsClients)
-	tm["CheckHealthy"] = CheckHealthy(awsClients)
-	tm["CleanUpSuccess"] = CleanUpSuccess(awsClients)
-	tm["CleanUpFailure"] = CleanUpFailure(awsClients)
-	tm["ReleaseLockFailure"] = ReleaseLockFailure(awsClients)
+	tm["Validate"] = Validate(awsc)
+	tm["Lock"] = Lock(awsc)
+	tm["ValidateResources"] = ValidateResources(awsc)
+	tm["Deploy"] = Deploy(awsc)
+	tm["CheckHealthy"] = CheckHealthy(awsc)
+	tm["CleanUpSuccess"] = CleanUpSuccess(awsc)
+	tm["CleanUpFailure"] = CleanUpFailure(awsc)
+	tm["ReleaseLockFailure"] = ReleaseLockFailure(awsc)
 	return &tm
 }

--- a/deployer/models/autoscaling.go
+++ b/deployer/models/autoscaling.go
@@ -8,11 +8,13 @@ import (
 
 // AutoScalingConfig struct
 type AutoScalingConfig struct {
-	MinSize         *int64    `json:"min_size,omitempty"`
-	MaxSize         *int64    `json:"max_size,omitempty"`
-	MaxTerminations *int64    `json:"max_terms,omitempty"`
-	Spread          *float64  `json:"spread,omitempty"`
-	Policies        []*Policy `json:"policies,omitempty"`
+	MinSize                *int64    `json:"min_size,omitempty"`
+	MaxSize                *int64    `json:"max_size,omitempty"`
+	MaxTerminations        *int64    `json:"max_terms,omitempty"`
+	DefaultCooldown        *int64    `json:"default_cooldown,omitempty"`
+	HealthCheckGracePeriod *int64    `json:"health_check_grace_period,omitempty"`
+	Spread                 *float64  `json:"spread,omitempty"`
+	Policies               []*Policy `json:"policies,omitempty"`
 }
 
 // MinSizeInt returns min size

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -130,11 +130,16 @@ func MockRelease(t *testing.T) *Release {
           "max_size": 1,
           "max_terms": 0,
           "spread": 0.5,
+          "default_cooldown": 10,
+          "health_check_grace_period": 10,
           "policies": [
             {
+              "name": "asd",
               "type": "cpu_scale_up",
               "scaling_adjustment": 5,
-              "threshold" : 25
+              "threshold" : 25,
+              "period": 2,
+              "evaluation_periods": 10
             },
             {
               "type": "cpu_scale_down",

--- a/deployer/models/policy.go
+++ b/deployer/models/policy.go
@@ -17,6 +17,7 @@ const cpuScaleUp = "cpu_scale_up"
 type Policy struct {
 	serviceID *string
 
+	NameVal              *string  `json:"name,omitempty"`
 	Type                 *string  `json:"type,omitempty"`
 	ScalingAdjustmentVal *int64   `json:"scaling_adjustment,omitempty"`
 	ThresholdVal         *float64 `json:"threshold,omitempty"`
@@ -25,8 +26,11 @@ type Policy struct {
 	CooldownVal          *int64   `json:"cooldown,omitempty"`
 }
 
-// Name returns name
 func (a *Policy) Name() *string {
+	if a.NameVal != nil {
+		return a.NameVal
+	}
+
 	return to.Strp(fmt.Sprintf("%v-%v", *a.serviceID, *a.Type))
 }
 
@@ -130,6 +134,7 @@ func (a *Policy) ValidateAttributes() error {
 // SetDefaults assigns default values
 func (a *Policy) SetDefaults(serviceID *string) error {
 	a.serviceID = serviceID
+
 	return nil
 }
 

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -41,7 +41,6 @@ type Release struct {
 
 	userdata       *string // Not serialized
 	UserDataSHA256 *string `json:"user_data_sha256,omitempty"`
-	UserDataKMSKey *string `json:"user_data_kms_key,omitempty"`
 
 	// LifeCycleHooks
 	LifeCycleHooks map[string]*LifeCycleHook `json:"lifecycle,omitempty"`
@@ -148,8 +147,6 @@ func (release *Release) SetDefaults() {
 		release.Healthy = to.Boolp(false)
 	}
 
-	release.SetDefaultKMSKey()
-
 	for name, lc := range release.LifeCycleHooks {
 		if lc != nil {
 			lc.SetDefaults(release.AwsRegion, release.AwsAccountID, name)
@@ -160,14 +157,6 @@ func (release *Release) SetDefaults() {
 		if service != nil {
 			service.SetDefaults(release, name)
 		}
-	}
-}
-
-// SetDefaultKMSKey sets the default KMS key to be used
-func (release *Release) SetDefaultKMSKey() {
-	if release.UserDataKMSKey == nil {
-		// Default alias to the default s3 KMS key
-		release.UserDataKMSKey = to.Strp("alias/aws/s3")
 	}
 }
 

--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -365,6 +365,9 @@ func (service *Service) createInput() *asg.Input {
 	input.MinSize = service.Autoscaling.MinSize
 	input.MaxSize = service.Autoscaling.MaxSize
 
+	input.DefaultCooldown = service.Autoscaling.DefaultCooldown
+	input.HealthCheckGracePeriod = service.Autoscaling.HealthCheckGracePeriod
+
 	input.DesiredCapacity = to.Int64p(int64(service.targetCapacity()))
 
 	input.LoadBalancerNames = service.Resources.ELBs

--- a/deployer/models/service_resources.go
+++ b/deployer/models/service_resources.go
@@ -27,6 +27,7 @@ type pcsresourceIface interface {
 	ProjectName() *string
 	ConfigName() *string
 	ServiceName() *string
+	Name() *string
 }
 
 // ServiceResources struct
@@ -307,15 +308,15 @@ func validateProjectConfigServiceNames(prefix string, service serviceIface, r pc
 	}
 
 	if !aws.HasProjectName(r, service.ProjectName()) && !aws.HasAllValue(r.ProjectName()) {
-		return fmt.Errorf("%v incorrect ProjectName requires %q has %q", prefix, to.Strs(service.ProjectName()), to.Strs(r.ProjectName()))
+		return fmt.Errorf("%v(%v) incorrect ProjectName requires %q has %q", prefix, to.Strs(r.Name()), to.Strs(service.ProjectName()), to.Strs(r.ProjectName()))
 	}
 
 	if !aws.HasConfigName(r, service.ConfigName()) && !aws.HasAllValue(r.ConfigName()) {
-		return fmt.Errorf("%v incorrect ConfigName requires %q has %q", prefix, to.Strs(service.ConfigName()), to.Strs(r.ConfigName()))
+		return fmt.Errorf("%v(%v) incorrect ConfigName requires %q has %q", prefix, to.Strs(r.Name()), to.Strs(service.ConfigName()), to.Strs(r.ConfigName()))
 	}
 
 	if !aws.HasServiceName(r, service.Name()) && !aws.HasAllValue(r.ServiceName()) {
-		return fmt.Errorf("%v incorrect ServiceName requires %q has %q", prefix, to.Strs(service.Name()), to.Strs(r.ServiceName()))
+		return fmt.Errorf("%v(%v) incorrect ServiceName requires %q has %q", prefix, to.Strs(r.Name()), to.Strs(service.Name()), to.Strs(r.ServiceName()))
 	}
 
 	return nil

--- a/odin.go
+++ b/odin.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/coinbase/odin/deployer"
 	"github.com/coinbase/odin/deployer/client"
+	"github.com/coinbase/step/utils/is"
 	"github.com/coinbase/step/utils/run"
+	"github.com/coinbase/step/utils/to"
 )
 
 func main() {
@@ -25,19 +27,25 @@ func main() {
 		printUsage() // Print how to use and exit
 	}
 
+	step_fn := to.Strp(os.Getenv("ODIN_STEP"))
+
+	if is.EmptyStr(step_fn) {
+		step_fn = to.Strp("coinbase-odin")
+	}
+
 	switch command {
 	case "json":
 		run.JSON(deployer.StateMachine())
 	case "deploy":
 		// Send Configuration to the deployer
 		// arg is a filename
-		err := client.Deploy(&arg)
+		err := client.Deploy(step_fn, &arg)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}
 	case "halt":
-		err := client.Halt(&arg)
+		err := client.Halt(step_fn, &arg)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -23,7 +23,7 @@
     },
     "web": {
       "instance_type": "t2.nano",
-      "security_groups": ["ec2::coinbase/deploy-test::development"],
+      "security_groups": ["ec2::default", "ec2::coinbase/deploy-test::development"],
       "elbs": [
         "coinbase-deploy-test-web-elb"
       ],


### PR DESCRIPTION
KMS key is entirely on the client not on the deployer

This PR also:
1. makes some better error messages.
1. Allows for ASGs to be tagged ReleaseId or ReleaseID
1. fixes Security Group and Subnet querying
1. allows selecting the step function to deploy to on the command line using envvar
