### PR TITLE
Revert "[Fix] SerivceId should be limited to 80 Characters for ASG and LC names"

### DIFF
--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -106,33 +106,13 @@ func (service *Service) CreatedAt() *time.Time {
 }
 
 // ServiceID returns a formatted string of the services ID
-// Must be equal or less than 80 Char for ASG and Launch Config Name
 func (service *Service) ServiceID() *string {
 	if service.ProjectName() == nil || service.ConfigName() == nil || service.ServiceName == nil || service.CreatedAt() == nil {
 		return nil
 	}
 
-	timeFormat := strings.Replace(service.CreatedAt().UTC().Format(time.RFC3339), ":", "-", -1)
-
-	serviceFormat := fmt.Sprintf("%v-%v", timeFormat, *service.ServiceName)
-	projectFormat := fmt.Sprintf("%v-%v", *service.ProjectName(), *service.ConfigName())
-	name := fmt.Sprintf("%v-%v", projectFormat, serviceFormat)
-
-	target := 80
-	if len(name) > target {
-		diff := len(name) - target
-		cut := len(projectFormat) - diff
-
-		// If we are slicing out of bounds
-		if cut < 0 || cut >= len(projectFormat) {
-			// Should not happen due to CHAR limit on ServiceName, but being defensive here
-			return to.Strp(name[:target])
-		}
-
-		name = fmt.Sprintf("%v-%v", projectFormat[:cut], serviceFormat)
-	}
-
-	return to.Strp(name)
+	tf := strings.Replace(service.CreatedAt().UTC().Format(time.RFC3339), ":", "-", -1)
+	return to.Strp(fmt.Sprintf("%v-%v-%v-%v", *service.ProjectName(), *service.ConfigName(), tf, *service.ServiceName))
 }
 
 // Subnets returns subnets
@@ -276,10 +256,6 @@ func (service *Service) Validate() error {
 func (service *Service) ValidateAttributes() error {
 	if is.EmptyStr(service.ServiceName) {
 		return fmt.Errorf("ServiceName must be defined")
-	}
-
-	if len(*service.ServiceName) > 20 {
-		return fmt.Errorf("ServiceName must be less than or equal to 20 char long")
 	}
 
 	if is.EmptyStr(service.InstanceType) {

--- a/deployer/models/service_test.go
+++ b/deployer/models/service_test.go
@@ -3,9 +3,7 @@ package models
 import (
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/coinbase/step/bifrost"
 	"github.com/coinbase/step/utils/to"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,24 +16,4 @@ func Test_Service_SetGetUserdata(t *testing.T) {
 	service.SetDefaults(release, "web")
 
 	assert.Equal(t, fmt.Sprintf("%v\n%v\n%v\nweb\n", *release.ReleaseID, *release.ProjectName, *release.ConfigName), *service.UserData())
-}
-
-func Test_Service_ServiceID(t *testing.T) {
-	release := &Release{Release: bifrost.Release{ProjectName: to.Strp("project"), ConfigName: to.Strp("config"), CreatedAt: &time.Time{}}}
-	service := &Service{
-		release:     release,
-		ServiceName: to.Strp("service"),
-	}
-
-	assert.Equal(t, *service.ServiceID(), "project-config-0001-01-01T00-00-00Z-service")
-
-	service.ServiceName = to.Strp("this_will_cause_a_name_longer_than_80_characters")
-	assert.Equal(t, *service.ServiceID(), "project-co-0001-01-01T00-00-00Z-this_will_cause_a_name_longer_than_80_characters")
-	assert.Equal(t, len(*service.ServiceID()), 80)
-
-	// This should not happen due to Char limit on ServiceName, but still should not error
-	service.ServiceName = to.Strp("this_will_cause_a_name_longer_than_80_characters_which_is_longer_than_the_max_crazzy")
-	assert.Equal(t, *service.ServiceID(), "project-config-0001-01-01T00-00-00Z-this_will_cause_a_name_longer_than_80_charac")
-	assert.Equal(t, len(*service.ServiceID()), 80)
-
 }


### PR DESCRIPTION
Reverts coinbase/odin#16

Length is 255, which should not be an issue. 