### PR TITLE
typo in UnsuccssfulTearDown func name

### DIFF
--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -160,7 +160,7 @@ func CleanUpFailure(awsc aws.Clients) DeployHandler {
 
 		release.Success = to.Boolp(false) // Quickly Mark Failure
 
-		if err := release.UnsuccssfulTearDown(
+		if err := release.UnsuccessfulTearDown(
 			awsc.ASGClient(release.AwsRegion, release.AwsAccountID, assumedRole),
 			awsc.CWClient(release.AwsRegion, release.AwsAccountID, assumedRole),
 		); err != nil {

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -175,8 +175,8 @@ func (release *Release) SuccessfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error
 	return nil
 }
 
-// UnsuccssfulTearDown deletes the services we were trying to create because :(
-func (release *Release) UnsuccssfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error {
+// UnsuccessfulTearDown deletes the services we were trying to create because :(
+func (release *Release) UnsuccessfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error {
 	// Tear down all resources in this release
 	asgs, err := asg.ForProjectConfigReleaseID(asgc, release.ProjectName, release.ConfigName, release.ReleaseID)
 	if err != nil {

--- a/deployer/models/release_resources_test.go
+++ b/deployer/models/release_resources_test.go
@@ -74,11 +74,11 @@ func Test_Release_SuccessfulTearDown_Works(t *testing.T) {
 	assert.NoError(t, r.SuccessfulTearDown(awsc.ASG, awsc.CW))
 }
 
-func Test_Release_UnsuccssfulTearDown_Works(t *testing.T) {
-	// func (release *Release) UnsuccssfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error {
+func Test_Release_UnsuccessfulTearDown_Works(t *testing.T) {
+	// func (release *Release) UnsuccessfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error {
 	r := MockRelease(t)
 	MockPrepareRelease(r)
 
 	awsc := MockAwsClients(r)
-	assert.NoError(t, r.UnsuccssfulTearDown(awsc.ASG, awsc.CW))
+	assert.NoError(t, r.UnsuccessfulTearDown(awsc.ASG, awsc.CW))
 }


### PR DESCRIPTION
## Summary of feature/typo-unsuccessful-function

- It seems that there is a typo in the UnsuccssfulTearDown function

## Steps to test

- Change from UnsuccssfulTearDown => UnsuccessfulTearDown

## Considerations

This might not be an actual typo.