### PR TITLE
Default health check grace period

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,6 +75,28 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/coinbase/odin"
+  packages = [
+    "aws",
+    "aws/alarms",
+    "aws/alb",
+    "aws/ami",
+    "aws/asg",
+    "aws/elb",
+    "aws/iam",
+    "aws/lc",
+    "aws/mocks",
+    "aws/sg",
+    "aws/sns",
+    "aws/subnet",
+    "client",
+    "deployer",
+    "deployer/models"
+  ]
+  revision = "3866512be2dd7ba3030364b1b1c7a40e67d3e3e8"
+
+[[projects]]
+  branch = "master"
   name = "github.com/coinbase/step"
   packages = [
     "aws",
@@ -131,6 +153,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fde601bb4cf2aff5273145a37ec762fc78b01afb9b3974c4bfc140d65c70ca4e"
+  inputs-digest = "9505edde78351a4d518feb2bae2bd07af3831d501fbb4a8f49e5002f65a40a57"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/deployer/models/autoscaling_test.go
+++ b/deployer/models/autoscaling_test.go
@@ -9,8 +9,27 @@ import (
 
 func Test_Autoscaling_Valid(t *testing.T) {
 	asg := &AutoScalingConfig{}
-	asg.SetDefaults(nil)
+	asg.SetDefaults(nil, nil)
 	assert.NoError(t, asg.ValidateAttributes())
+}
+
+func Test_Autoscaling_HealthCheckGracePeriod(t *testing.T) {
+	asg := &AutoScalingConfig{}
+	assert.Nil(t, asg.HealthCheckGracePeriod)
+
+	// Default to timeout
+	asg.SetDefaults(nil, to.Intp(10))
+	assert.Equal(t, *asg.HealthCheckGracePeriod, int64(10))
+
+	// Min to timeout
+	asg.HealthCheckGracePeriod = to.Int64p(100)
+	asg.SetDefaults(nil, to.Intp(20))
+	assert.Equal(t, *asg.HealthCheckGracePeriod, int64(20))
+
+	// min to HealthCheck
+	asg.HealthCheckGracePeriod = to.Int64p(100)
+	asg.SetDefaults(nil, to.Intp(2000))
+	assert.Equal(t, *asg.HealthCheckGracePeriod, int64(100))
 }
 
 func Test_DesiredCapacity(t *testing.T) {

--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -373,12 +373,22 @@ func (service *Service) createInput() *asg.Input {
 	input.MaxSize = service.Autoscaling.MaxSize
 
 	input.DefaultCooldown = service.Autoscaling.DefaultCooldown
-	input.HealthCheckGracePeriod = service.Autoscaling.HealthCheckGracePeriod
 
 	input.DesiredCapacity = to.Int64p(int64(service.targetCapacity()))
 
 	input.LoadBalancerNames = service.Resources.ELBs
 	input.TargetGroupARNs = service.Resources.TargetGroups
+
+	if service.Autoscaling.HealthCheckGracePeriod == nil {
+		input.HealthCheckGracePeriod = to.Int64p(int64(*service.release.Timeout))
+	} else {
+		// If grace period is specified, make sure it is not > timeout
+		input.HealthCheckGracePeriod = to.Int64p(int64(
+			min(
+				int(*service.Autoscaling.HealthCheckGracePeriod),
+				int(*service.release.Timeout)),
+		))
+	}
 
 	input.VPCZoneIdentifier = service.SubnetIds()
 	input.LifecycleHookSpecificationList = service.LifeCycleHookSpecs()

--- a/deployer/models/service_test.go
+++ b/deployer/models/service_test.go
@@ -17,3 +17,15 @@ func Test_Service_SetGetUserdata(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("%v\n%v\n%v\nweb\n", *release.ReleaseID, *release.ProjectName, *release.ConfigName), *service.UserData())
 }
+
+func Test_Service_CreateInput_HealthCheckGracePeriod(t *testing.T) {
+	release := MockMinimalRelease(t)
+	release.Timeout = to.Intp(10)
+
+	service := Service{}
+	service.SetUserData(to.Strp("{{RELEASE_ID}}\n{{PROJECT_NAME}}\n{{CONFIG_NAME}}\n{{SERVICE_NAME}}\n"))
+	service.SetDefaults(release, "web")
+
+	input := service.createInput()
+	assert.Equal(t, *input.HealthCheckGracePeriod, int64(10))
+}


### PR DESCRIPTION
Make health_check_grace_period default to timeout, otherwise validate it by making sure it is not greater than timeout if manually specified.