### PR TITLE
[Feature] Let Odin pick the spot price bid at 1% above OnDemand price

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/pricing/pricingiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sfn"
@@ -169,6 +171,9 @@ type SNSAPI snsiface.SNSAPI
 // SFNAPI aws API
 type SFNAPI sfniface.SFNAPI
 
+// PricingAPI aws API
+type PricingAPI pricingiface.PricingAPI
+
 // Clients for AWS
 type Clients interface {
 	S3Client(region *string, accountID *string, role *string) S3API
@@ -180,6 +185,7 @@ type Clients interface {
 	IAMClient(region *string, accountID *string, role *string) IAMAPI
 	SNSClient(region *string, accountID *string, role *string) SNSAPI
 	SFNClient(region *string, accountID *string, role *string) SFNAPI
+	PricingClient() PricingAPI
 }
 
 // ClientsStr implementation
@@ -230,4 +236,9 @@ func (awsc *ClientsStr) SNSClient(region *string, accountID *string, role *strin
 // SFNClient returns client for region account and role
 func (awsc *ClientsStr) SFNClient(region *string, accountID *string, role *string) SFNAPI {
 	return sfn.New(awsc.Session(), awsc.Config(region, accountID, role))
+}
+
+// PricingClient returns client, don't need to assume
+func (awsc *ClientsStr) PricingClient() PricingAPI {
+	return pricing.New(awsc.Session(), awsc.Config(nil, nil, nil))
 }

--- a/aws/cost/cost.go
+++ b/aws/cost/cost.go
@@ -139,7 +139,7 @@ func Cost(pricec aws.PricingAPI, region *string, instanceType *string) (*string,
 func SmartBidPrice(pricec aws.PricingAPI, region *string, instanceType *string) (*string, error) {
 	price, err := Cost(pricec, region, instanceType)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	pricef, err := strconv.ParseFloat(*price, 64)

--- a/aws/cost/cost.go
+++ b/aws/cost/cost.go
@@ -1,0 +1,154 @@
+package cost
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/coinbase/step/utils/is"
+
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/coinbase/odin/aws"
+	"github.com/coinbase/step/utils/to"
+)
+
+var REGIONS = map[string]string{
+	"us-east-2":      "US East (Ohio)",
+	"us-east-1":      "US East (N. Virginia)",
+	"us-west-1":      "US West (N. California)",
+	"us-west-2":      "US West (Oregon)",
+	"ap-south-1":     "Asia Pacific (Mumbai)",
+	"ap-northeast-3": "Asia Pacific (Osaka-Local)",
+	"ap-northeast-2": "Asia Pacific (Seoul)",
+	"ap-southeast-1": "Asia Pacific (Singapore)",
+	"ap-southeast-2": "Asia Pacific (Sydney)",
+	"ap-northeast-1": "Asia Pacific (Tokyo)",
+	"ca-central-1":   "Canada (Central)",
+	"cn-north-1":     "China (Beijing)",
+	"cn-northwest-1": "China (Ningxia)",
+	"eu-central-1":   "EU (Frankfurt)",
+	"eu-west-1":      "EU (Ireland)",
+	"eu-west-2":      "EU (London)",
+	"eu-west-3":      "EU (Paris)",
+	"sa-east-1":      "South America (São Paulo)",
+}
+
+type PriceDimension struct {
+	PricePerUnit struct {
+		USD *string `json:"USD"`
+	} `json:"pricePerUnit"`
+}
+
+type Term struct {
+	PriceDimensions map[string]PriceDimension `json:"priceDimensions"`
+}
+
+type Terms struct {
+	OnDemand map[string]Term `json:"OnDemand"`
+}
+
+// Cost returns the cost of an instance
+// This is a major PITA because the pricing API is very difficult to navigate
+func Cost(pricec aws.PricingAPI, region *string, instanceType *string) (*string, error) {
+	input := &pricing.GetProductsInput{
+		ServiceCode: to.Strp("AmazonEC2"),
+		Filters: []*pricing.Filter{
+			&pricing.Filter{
+				Field: to.Strp("operatingSystem"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: to.Strp("Linux"),
+			},
+			&pricing.Filter{
+				Field: to.Strp("operation"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: to.Strp("RunInstances"),
+			},
+			&pricing.Filter{
+				Field: to.Strp("capacitystatus"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: to.Strp("Used"),
+			},
+			&pricing.Filter{
+				Field: to.Strp("tenancy"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: to.Strp("Shared"),
+			},
+			&pricing.Filter{
+				Field: to.Strp("instanceType"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: instanceType,
+			},
+			&pricing.Filter{
+				Field: to.Strp("location"),
+				Type:  to.Strp("TERM_MATCH"),
+				Value: to.Strp(REGIONS[*region]),
+			},
+		},
+	}
+
+	p, err := pricec.GetProducts(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// expect only one price, otherwise could over/under price
+	if len(p.PriceList) != 1 {
+		return nil, fmt.Errorf("Princing Error: Expected len(PriceList) to eq 1 but was %v", len(p.PriceList))
+	}
+
+	termInput := p.PriceList[0]["terms"]
+
+	if termInput == nil {
+		return nil, fmt.Errorf("Princing Error: No terms")
+	}
+
+	termJSON, err := json.Marshal(termInput)
+	if err != nil {
+		return nil, err
+	}
+
+	var terms Terms
+	json.Unmarshal([]byte(termJSON), &terms)
+
+	if len(terms.OnDemand) != 1 {
+		return nil, fmt.Errorf("Princing Error: Expected len(OnDemand) to eq 1 but was %v", len(terms.OnDemand))
+	}
+
+	var term Term
+	for _, v := range terms.OnDemand {
+		term = v
+	}
+
+	if len(term.PriceDimensions) != 1 {
+		return nil, fmt.Errorf("Princing Error: Expected len(PriceDimension) to eq 1 but was %v", len(term.PriceDimensions))
+	}
+
+	var pd PriceDimension
+	for _, v := range term.PriceDimensions {
+		pd = v
+	}
+
+	if is.EmptyStr(pd.PricePerUnit.USD) {
+		return nil, fmt.Errorf("Princing Error: PricePerUnit.USD not found")
+	}
+
+	return pd.PricePerUnit.USD, nil
+}
+
+// SmartBidPrice returns a smart bid price for a Spot instance
+func SmartBidPrice(pricec aws.PricingAPI, region *string, instanceType *string) (*string, error) {
+	price, err := Cost(pricec, region, instanceType)
+	if err != nil {
+		return nil, nil
+	}
+
+	pricef, err := strconv.ParseFloat(*price, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Princing Error: Parsing Price %v", price)
+	}
+
+	// To ensure we keep the instances we increase bid by %1
+	pricef *= 1.01
+
+	return to.Strp(fmt.Sprintf("%f", pricef)), nil
+}

--- a/aws/cost/cost_test.go
+++ b/aws/cost/cost_test.go
@@ -1,0 +1,25 @@
+package cost
+
+import (
+	"testing"
+
+	"github.com/coinbase/odin/aws/mocks"
+	"github.com/coinbase/step/utils/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Cost(t *testing.T) {
+	pricec := &mocks.PricingClient{}
+	price, err := Cost(pricec, to.Strp("us-east-1"), to.Strp("r4.large"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, *price, "0.100000")
+}
+
+func Test_SmartBidPrice(t *testing.T) {
+	pricec := &mocks.PricingClient{}
+	price, err := SmartBidPrice(pricec, to.Strp("us-east-1"), to.Strp("r4.large"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, *price, "0.101000")
+}

--- a/aws/mocks/clients.go
+++ b/aws/mocks/clients.go
@@ -7,29 +7,31 @@ import (
 
 // MockClients struct
 type MockClients struct {
-	S3  *mocks.MockS3Client
-	ASG *ASGClient
-	ELB *ELBClient
-	EC2 *EC2Client
-	ALB *ALBClient
-	CW  *CWClient
-	IAM *IAMClient
-	SNS *SNSClient
-	SFN *mocks.MockSFNClient
+	S3    *mocks.MockS3Client
+	ASG   *ASGClient
+	ELB   *ELBClient
+	EC2   *EC2Client
+	ALB   *ALBClient
+	CW    *CWClient
+	IAM   *IAMClient
+	SNS   *SNSClient
+	SFN   *mocks.MockSFNClient
+	Price *PricingClient
 }
 
 // MockAWS mock clients
 func MockAWS() *MockClients {
 	return &MockClients{
-		S3:  &mocks.MockS3Client{},
-		ASG: &ASGClient{},
-		ELB: &ELBClient{},
-		EC2: &EC2Client{},
-		ALB: &ALBClient{},
-		CW:  &CWClient{},
-		IAM: &IAMClient{},
-		SNS: &SNSClient{},
-		SFN: &mocks.MockSFNClient{},
+		S3:    &mocks.MockS3Client{},
+		ASG:   &ASGClient{},
+		ELB:   &ELBClient{},
+		EC2:   &EC2Client{},
+		ALB:   &ALBClient{},
+		CW:    &CWClient{},
+		IAM:   &IAMClient{},
+		SNS:   &SNSClient{},
+		SFN:   &mocks.MockSFNClient{},
+		Price: &PricingClient{},
 	}
 }
 
@@ -76,4 +78,9 @@ func (a *MockClients) SNSClient(*string, *string, *string) aws.SNSAPI {
 // SFNClient returns
 func (a *MockClients) SFNClient(*string, *string, *string) aws.SFNAPI {
 	return a.SFN
+}
+
+// PricingClient returns
+func (a *MockClients) PricingClient() aws.PricingAPI {
+	return a.Price
 }

--- a/aws/mocks/mock_pricing.go
+++ b/aws/mocks/mock_pricing.go
@@ -9,42 +9,42 @@ import (
 
 var mockGetProductResponse = `
 {
-	"FormatVersion": "aws_v1",
-	"NextToken": null,
-	"PriceList": [
-			{
-					"product": {
-							"attributes": {
-									"instanceType": "r4.large"
-							}
-					},
-					"terms": {
-							"OnDemand": {
-									"THISISARANDOMSTRING": {
-											"priceDimensions": {
-													"THISISARANDOMSTRING": {
-															"pricePerUnit": {
-																	"USD": "0.100000"
-															}
-													}
-											}
-									}
-							},
-							"Reserved": {
-									"THISISARANDOMSTRING": {
-											"priceDimensions": {
-													"THISISARANDOMSTRING": {
-															"pricePerUnit": {
-																	"USD": "0.0270000000"
-															}
-													}
-											}
-									}
-							}
-					},
-					"version": "20181031070014"
-			}
-	]
+  "FormatVersion": "aws_v1",
+  "NextToken": null,
+  "PriceList": [
+      {
+          "product": {
+              "attributes": {
+                  "instanceType": "r4.large"
+              }
+          },
+          "terms": {
+              "OnDemand": {
+                  "THISISARANDOMSTRING": {
+                      "priceDimensions": {
+                          "THISISARANDOMSTRING": {
+                              "pricePerUnit": {
+                                  "USD": "0.100000"
+                              }
+                          }
+                      }
+                  }
+              },
+              "Reserved": {
+                  "THISISARANDOMSTRING": {
+                      "priceDimensions": {
+                          "THISISARANDOMSTRING": {
+                              "pricePerUnit": {
+                                  "USD": "0.0270000000"
+                              }
+                          }
+                      }
+                  }
+              }
+          },
+          "version": "20181031070014"
+      }
+  ]
 }
  `
 

--- a/aws/mocks/mock_pricing.go
+++ b/aws/mocks/mock_pricing.go
@@ -1,0 +1,61 @@
+package mocks
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/coinbase/odin/aws"
+)
+
+var mockGetProductResponse = `
+{
+	"FormatVersion": "aws_v1",
+	"NextToken": null,
+	"PriceList": [
+			{
+					"product": {
+							"attributes": {
+									"instanceType": "r4.large"
+							}
+					},
+					"terms": {
+							"OnDemand": {
+									"CGJXHFUSGE546RV6.JRTCKXETXF": {
+											"priceDimensions": {
+													"CGJXHFUSGE546RV6.JRTCKXETXF.6YS6EN2CT7": {
+															"pricePerUnit": {
+																	"USD": "0.100000"
+															}
+													}
+											}
+									}
+							},
+							"Reserved": {
+									"CGJXHFUSGE546RV6.38NPMPTW36": {
+											"priceDimensions": {
+													"CGJXHFUSGE546RV6.38NPMPTW36.6YS6EN2CT7": {
+															"pricePerUnit": {
+																	"USD": "0.0270000000"
+															}
+													}
+											}
+									}
+							}
+					},
+					"version": "20181031070014"
+			}
+	]
+}
+ `
+
+// CWClient struct
+type PricingClient struct {
+	aws.PricingAPI
+}
+
+// GetProducts returns
+func (m *PricingClient) GetProducts(input *pricing.GetProductsInput) (*pricing.GetProductsOutput, error) {
+	var pdo pricing.GetProductsOutput
+	json.Unmarshal([]byte(mockGetProductResponse), &pdo)
+	return &pdo, nil
+}

--- a/aws/mocks/mock_pricing.go
+++ b/aws/mocks/mock_pricing.go
@@ -20,9 +20,9 @@ var mockGetProductResponse = `
 					},
 					"terms": {
 							"OnDemand": {
-									"CGJXHFUSGE546RV6.JRTCKXETXF": {
+									"THISISARANDOMSTRING": {
 											"priceDimensions": {
-													"CGJXHFUSGE546RV6.JRTCKXETXF.6YS6EN2CT7": {
+													"THISISARANDOMSTRING": {
 															"pricePerUnit": {
 																	"USD": "0.100000"
 															}
@@ -31,9 +31,9 @@ var mockGetProductResponse = `
 									}
 							},
 							"Reserved": {
-									"CGJXHFUSGE546RV6.38NPMPTW36": {
+									"THISISARANDOMSTRING": {
 											"priceDimensions": {
-													"CGJXHFUSGE546RV6.38NPMPTW36.6YS6EN2CT7": {
+													"THISISARANDOMSTRING": {
 															"pricePerUnit": {
 																	"USD": "0.0270000000"
 															}
@@ -48,7 +48,7 @@ var mockGetProductResponse = `
 }
  `
 
-// CWClient struct
+// PricingClient struct
 type PricingClient struct {
 	aws.PricingAPI
 }

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -59,6 +59,7 @@ func ValidateResources(awsc aws.Clients) DeployHandler {
 			awsc.ALBClient(release.AwsRegion, release.AwsAccountID, assumedRole),
 			awsc.IAMClient(release.AwsRegion, release.AwsAccountID, assumedRole),
 			awsc.SNSClient(release.AwsRegion, release.AwsAccountID, assumedRole),
+			awsc.PricingClient(),
 		)
 
 		if err != nil {

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -15,7 +15,7 @@ import (
 
 // FetchResources checks the existence of all Resources references in this release
 // and returns a struct of the resources
-func (release *Release) FetchResources(asgc aws.ASGAPI, ec2 aws.EC2API, elbc aws.ELBAPI, albc aws.ALBAPI, iamc aws.IAMAPI, snsc aws.SNSAPI) (map[string]*ServiceResources, error) {
+func (release *Release) FetchResources(asgc aws.ASGAPI, ec2 aws.EC2API, elbc aws.ELBAPI, albc aws.ALBAPI, iamc aws.IAMAPI, snsc aws.SNSAPI, pricec aws.PricingAPI) (map[string]*ServiceResources, error) {
 	resources := map[string]*ServiceResources{}
 
 	// If there are any ASGs with this release ID error
@@ -53,7 +53,7 @@ func (release *Release) FetchResources(asgc aws.ASGAPI, ec2 aws.EC2API, elbc aws
 	}
 
 	for name, service := range release.Services {
-		sr, err := service.FetchResources(ec2, elbc, albc, iamc)
+		sr, err := service.FetchResources(ec2, elbc, albc, iamc, pricec)
 		if err != nil {
 			return nil, err
 		}

--- a/deployer/models/release_resources_test.go
+++ b/deployer/models/release_resources_test.go
@@ -13,7 +13,7 @@ func Test_Release_FetchResources_Works(t *testing.T) {
 
 	awsc := MockAwsClients(r)
 
-	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS)
+	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS, awsc.Price)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(sm))
@@ -26,7 +26,7 @@ func Test_Release_ValidateResources_Works(t *testing.T) {
 
 	awsc := MockAwsClients(r)
 
-	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS)
+	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS, awsc.Price)
 	assert.NoError(t, err)
 
 	assert.NoError(t, r.ValidateResources(sm))
@@ -39,7 +39,7 @@ func Test_Release_UpdateWithResources_Works(t *testing.T) {
 
 	awsc := MockAwsClients(r)
 
-	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS)
+	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS, awsc.Price)
 	assert.NoError(t, err)
 
 	r.UpdateWithResources(sm)

--- a/deployer/models/release_resources_test.go
+++ b/deployer/models/release_resources_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"testing"
 
+	"github.com/coinbase/step/utils/to"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,6 +31,19 @@ func Test_Release_ValidateResources_Works(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, r.ValidateResources(sm))
+}
+
+func Test_Release_FetchResource_SpotPrice(t *testing.T) {
+	r := MockRelease(t)
+	MockPrepareRelease(r)
+
+	r.Services["web"].SmartSpotPrice = to.Boolp(true)
+
+	awsc := MockAwsClients(r)
+	_, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS, awsc.Price)
+
+	assert.NoError(t, err)
+	assert.Equal(t, *r.Services["web"].SpotPrice, "0.101000")
 }
 
 func Test_Release_UpdateWithResources_Works(t *testing.T) {

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -19,10 +19,12 @@
     "worker": {
       "instance_type": "t2.nano",
       "security_groups": ["ec2::default"],
-      "profile": "default-profile"
+      "profile": "default-profile",
+      "smart_spot_price": true
     },
     "web": {
-      "instance_type": "t2.nano",
+      "smart_spot_price": true,
+      "instance_type": "t2.medium",
       "security_groups": ["ec2::default", "ec2::coinbase/deploy-test::development"],
       "elbs": [
         "coinbase-deploy-test-web-elb"

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -1,7 +1,7 @@
 {
   "project_name": "coinbase/deploy-test",
   "config_name": "development",
-  "timeout": 240,
+  "timeout": 500,
   "subnets": [
     "test_private_subnet_a",
     "test_private_subnet_b"
@@ -17,14 +17,14 @@
   },
   "services": {
     "worker": {
-      "instance_type": "t2.nano",
+      "instance_type": "c5.large",
       "security_groups": ["ec2::default"],
       "profile": "default-profile",
       "smart_spot_price": true
     },
     "web": {
       "smart_spot_price": true,
-      "instance_type": "t2.medium",
+      "instance_type": "c5.large",
       "security_groups": ["ec2::default", "ec2::coinbase/deploy-test::development"],
       "elbs": [
         "coinbase-deploy-test-web-elb"

--- a/releases/deploy-test-release.json
+++ b/releases/deploy-test-release.json
@@ -8,7 +8,7 @@
   ],
   "ami": "ubuntu",
   "lifecycle": {
-    "termhook" : {
+    "termhook": {
       "transition": "autoscaling:EC2_INSTANCE_TERMINATING",
       "role": "asg_lifecycle_hooks",
       "sns": "asg_lifecycle_hooks",
@@ -42,12 +42,12 @@
         "policies": [
           {
             "type": "cpu_scale_up",
-            "threshold" : 25,
+            "threshold": 25,
             "scaling_adjustment": 2
           },
           {
             "type": "cpu_scale_down",
-            "threshold" : 15,
+            "threshold": 15,
             "scaling_adjustment": -1
           }
         ]

--- a/resources/odin_lambda_policy.json.erb
+++ b/resources/odin_lambda_policy.json.erb
@@ -8,6 +8,11 @@
     },
     {
       "Effect": "Allow",
+      "Action": "pricing:GetProducts",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
       "Action": [
         "s3:GetObject*",
         "s3:PutObject*",

--- a/scripts/geo
+++ b/scripts/geo
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-export GEO_ENV=step
+export GEO_ENV=development
 bundle exec geo $@


### PR DESCRIPTION
Using Spot instances is annoying because looking up a bid price per instance type is annoying. This PR uses the Pricing API to find the OnDemand instance value then adds 1% to that so that we can maintain instances through runs on the bank. In the short and long run this should still save money.

I think the biggest problem with spot instances is now selecting the instance type given that there are many similar instance types that are priced about the same amount but have very different spot instance availability. I think the next step will be to put something like `instance_cpu: 2, instance_mem: 4` then try find an instance that is similar enough with spot availability (if spot is used)