### PR TITLE
[Fix] ensure policy name uniqness

### DIFF
--- a/deployer/models/autoscaling.go
+++ b/deployer/models/autoscaling.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 
+	"github.com/coinbase/step/utils/is"
 	"github.com/coinbase/step/utils/to"
 )
 
@@ -63,6 +64,8 @@ func (a *AutoScalingConfig) ValidateAttributes() error {
 		return fmt.Errorf("Spread must be between 0 and 1")
 	}
 
+	policyNames := []*string{}
+
 	for _, p := range a.Policies {
 		if p == nil {
 			return fmt.Errorf("Policy nil")
@@ -71,7 +74,14 @@ func (a *AutoScalingConfig) ValidateAttributes() error {
 		if err := p.ValidateAttributes(); err != nil {
 			return err
 		}
+
+		policyNames = append(policyNames, p.Name())
 	}
+
+	if !is.UniqueStrp(policyNames) {
+		return fmt.Errorf("Policy Names not Unique")
+	}
+
 	return nil
 }
 

--- a/deployer/models/autoscaling_test.go
+++ b/deployer/models/autoscaling_test.go
@@ -13,6 +13,23 @@ func Test_Autoscaling_Valid(t *testing.T) {
 	assert.NoError(t, asg.ValidateAttributes())
 }
 
+func Test_PolicyNames_Uniq(t *testing.T) {
+	asg := &AutoScalingConfig{
+		Policies: []*Policy{
+			&Policy{Type: to.Strp("cpu_scale_down")},
+			&Policy{Type: to.Strp("cpu_scale_up")},
+		},
+	}
+	asg.SetDefaults(to.Strp("service_id"), nil)
+	assert.NoError(t, asg.ValidateAttributes())
+
+	asg.Policies[0].Type = to.Strp("cpu_scale_up")
+	assert.Error(t, asg.ValidateAttributes())
+
+	asg.Policies[0].NameVal = to.Strp("override_name")
+	assert.NoError(t, asg.ValidateAttributes())
+}
+
 func Test_Autoscaling_HealthCheckGracePeriod(t *testing.T) {
 	asg := &AutoScalingConfig{}
 	assert.Nil(t, asg.HealthCheckGracePeriod)

--- a/deployer/models/policy.go
+++ b/deployer/models/policy.go
@@ -27,12 +27,11 @@ type Policy struct {
 }
 
 func (a *Policy) Name() *string {
-	name := a.NameVal
-	if name == nil {
-		name = a.Type
+	if a.NameVal != nil {
+		return to.Strp(fmt.Sprintf("%v-%v-%v", *a.serviceID, *a.Type, *a.NameVal))
 	}
 
-	return to.Strp(fmt.Sprintf("%v-%v", *a.serviceID, *name))
+	return to.Strp(fmt.Sprintf("%v-%v", *a.serviceID, *a.Type))
 }
 
 // ScalingAdjustment returns up or down adjustment

--- a/deployer/models/policy.go
+++ b/deployer/models/policy.go
@@ -27,11 +27,12 @@ type Policy struct {
 }
 
 func (a *Policy) Name() *string {
-	if a.NameVal != nil {
-		return a.NameVal
+	name := a.NameVal
+	if name == nil {
+		name = a.Type
 	}
 
-	return to.Strp(fmt.Sprintf("%v-%v", *a.serviceID, *a.Type))
+	return to.Strp(fmt.Sprintf("%v-%v", *a.serviceID, *name))
 }
 
 // ScalingAdjustment returns up or down adjustment

--- a/deployer/models/policy_test.go
+++ b/deployer/models/policy_test.go
@@ -27,5 +27,5 @@ func Test_Policy_Name_Prefix(t *testing.T) {
 	assert.Equal(t, *pol.Name(), "service_id-cpu_scale_down")
 
 	pol.NameVal = to.Strp("boom")
-	assert.Equal(t, *pol.Name(), "service_id-boom")
+	assert.Equal(t, *pol.Name(), "service_id-cpu_scale_down-boom")
 }

--- a/deployer/models/policy_test.go
+++ b/deployer/models/policy_test.go
@@ -16,3 +16,16 @@ func Test_Policy_Valid(t *testing.T) {
 
 	assert.NoError(t, pol.ValidateAttributes())
 }
+
+func Test_Policy_Name_Prefix(t *testing.T) {
+	pol := &Policy{
+		Type: to.Strp("cpu_scale_down"),
+	}
+
+	pol.SetDefaults(to.Strp("service_id"))
+
+	assert.Equal(t, *pol.Name(), "service_id-cpu_scale_down")
+
+	pol.NameVal = to.Strp("boom")
+	assert.Equal(t, *pol.Name(), "service_id-boom")
+}


### PR DESCRIPTION
An issue was raised where policies wont necessarily have unique names which can cause issues.

This will:
1. generate more unique names for services that do specify names
2. be invalid if two policies don't have unique names
