### PR TITLE
[odin] enable autoscaling metrics; set tag propagate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.out
 coverage.html
 vendor
 odin
+odin2

--- a/aws/asg/asg_input.go
+++ b/aws/asg/asg_input.go
@@ -76,7 +76,7 @@ func (s *Input) AddTag(key string, value *string) {
 	}
 
 	// Add new Tag
-	s.Tags = append(s.Tags, &autoscaling.Tag{Key: &key, Value: value})
+	s.Tags = append(s.Tags, &autoscaling.Tag{Key: &key, Value: value, PropagateAtLaunch: to.Boolp(true)})
 }
 
 // ToASG returns ASG object

--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -209,6 +209,11 @@ func (m *ASGClient) DescribePolicies(in *autoscaling.DescribePoliciesInput) (*au
 	return resp.Resp, resp.Error
 }
 
+// EnableMetricsCollection returns
+func (m *ASGClient) EnableMetricsCollection(input *autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error) {
+	return nil, nil
+}
+
 // PutScalingPolicy returns
 func (m *ASGClient) PutScalingPolicy(input *autoscaling.PutScalingPolicyInput) (*autoscaling.PutScalingPolicyOutput, error) {
 	return &autoscaling.PutScalingPolicyOutput{PolicyARN: to.Strp("arn")}, nil


### PR DESCRIPTION
* Enables metric collection for autoscaling groups. Does not make it configurable.
* Sets the default to propagate tags on autoscaling groups (the default).

Reference:

* API: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html
* SetEnabledMetrics: https://docs.aws.amazon.com/sdk-for-go/api/service/autoscaling/#Group.SetEnabledMetrics
* EnabledMetric: https://docs.aws.amazon.com/sdk-for-go/api/service/autoscaling/#EnabledMetric

Local tests:
```
 go test ./...
?   	github.com/coinbase/odin	[no test files]
ok  	github.com/coinbase/odin/aws	(cached)
ok  	github.com/coinbase/odin/aws/alarms	(cached)
ok  	github.com/coinbase/odin/aws/alb	(cached)
ok  	github.com/coinbase/odin/aws/ami	(cached)
ok  	github.com/coinbase/odin/aws/asg	(cached)
ok  	github.com/coinbase/odin/aws/elb	(cached)
ok  	github.com/coinbase/odin/aws/iam	(cached)
ok  	github.com/coinbase/odin/aws/lc	(cached)
?   	github.com/coinbase/odin/aws/mocks	[no test files]
ok  	github.com/coinbase/odin/aws/sg	(cached)
?   	github.com/coinbase/odin/aws/sns	[no test files]
ok  	github.com/coinbase/odin/aws/subnet	(cached)
ok  	github.com/coinbase/odin/client	(cached)
ok  	github.com/coinbase/odin/deployer	(cached)
ok  	github.com/coinbase/odin/deployer/models	(cached)
```

Internal tracking: INFRA-2964, INFRA-2816.