### PR TITLE
[FEATURE] Allow TG's to nominate allowed services

### DIFF
--- a/aws/alb/target_group.go
+++ b/aws/alb/target_group.go
@@ -40,6 +40,9 @@ func (s *TargetGroup) Name() *string {
 
 // AllowedService returns which service is allowed to attach to it
 func (s *TargetGroup) AllowedService() *string {
+	if s.ProjectNameTag == nil || s.ConfigNameTag == nil || s.ServiceNameTag == nil {
+		return to.Strp("no services allowed")
+	}
 	if s.AllowedServiceTag == nil {
 		return to.Strp(fmt.Sprintf("%s::%s::%s", *s.ProjectName(), *s.ConfigName(), *s.ServiceName()))
 	}

--- a/aws/alb/target_group.go
+++ b/aws/alb/target_group.go
@@ -10,11 +10,12 @@ import (
 
 // TargetGroup struct
 type TargetGroup struct {
-	ProjectNameTag  *string
-	ConfigNameTag   *string
-	ServiceNameTag  *string
-	TargetGroupArn  *string
-	TargetGroupName *string
+	ProjectNameTag    *string
+	ConfigNameTag     *string
+	ServiceNameTag    *string
+	AllowedServiceTag *string
+	TargetGroupArn    *string
+	TargetGroupName   *string
 }
 
 // ProjectName returns tag
@@ -32,8 +33,17 @@ func (s *TargetGroup) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+// Name returns tag
 func (s *TargetGroup) Name() *string {
 	return s.TargetGroupName
+}
+
+// AllowedService returns which service is allowed to attach to it
+func (s *TargetGroup) AllowedService() *string {
+	if s.AllowedServiceTag == nil {
+		return to.Strp(fmt.Sprintf("%s::%s::%s", *s.ProjectName(), *s.ConfigName(), *s.ServiceName()))
+	}
+	return s.AllowedServiceTag
 }
 
 //////
@@ -98,11 +108,12 @@ func find(alb aws.ALBAPI, targetGroupName *string) (*TargetGroup, error) {
 	}
 
 	return &TargetGroup{
-		ProjectNameTag:  aws.FetchELBV2Tag(awsTags, to.Strp("ProjectName")),
-		ConfigNameTag:   aws.FetchELBV2Tag(awsTags, to.Strp("ConfigName")),
-		ServiceNameTag:  aws.FetchELBV2Tag(awsTags, to.Strp("ServiceName")),
-		TargetGroupArn:  awsTarget.TargetGroupArn,
-		TargetGroupName: targetGroupName,
+		ProjectNameTag:    aws.FetchELBV2Tag(awsTags, to.Strp("ProjectName")),
+		ConfigNameTag:     aws.FetchELBV2Tag(awsTags, to.Strp("ConfigName")),
+		ServiceNameTag:    aws.FetchELBV2Tag(awsTags, to.Strp("ServiceName")),
+		AllowedServiceTag: aws.FetchELBV2Tag(awsTags, to.Strp("AllowedService")),
+		TargetGroupArn:    awsTarget.TargetGroupArn,
+		TargetGroupName:   targetGroupName,
 	}, nil
 }
 

--- a/aws/alb/target_group_test.go
+++ b/aws/alb/target_group_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_AllowedService_ExplicitValue(t *testing.T) {
+	explicitService := "other/project::other-config::other-service"
+
+	tg := TargetGroup{
+		ProjectNameTag:    to.Strp("project"),
+		ConfigNameTag:     to.Strp("config"),
+		ServiceNameTag:    to.Strp("service"),
+		AllowedServiceTag: to.Strp(explicitService),
+	}
+	service := tg.AllowedService()
+	assert.Equal(t, *service, explicitService)
+}
+
+func Test_AllowedService_ImplicitValue(t *testing.T) {
+	tg := TargetGroup{
+		ProjectNameTag: to.Strp("project"),
+		ConfigNameTag:  to.Strp("config"),
+		ServiceNameTag: to.Strp("service"),
+	}
+	service := tg.AllowedService()
+	assert.Equal(t, *service, "project::config::service")
+}
+
 func Test_FindAll_Empty(t *testing.T) {
 	albc := &mocks.ALBClient{}
 	am, err := FindAll(albc, []*string{})
@@ -24,8 +47,8 @@ func Test_FindAll_NotFound(t *testing.T) {
 
 func Test_FindAll_Found(t *testing.T) {
 	albc := &mocks.ALBClient{}
-	albc.AddTargetGroup("tg_name", "project_name", "config_name", "service_name")
-	albc.AddTargetGroup("tg_other_name", "project_name", "config_name", "service_name")
+	albc.AddTargetGroup(mocks.MockTargetGroup{})
+	albc.AddTargetGroup(mocks.MockTargetGroup{Name: "tg_other_name"})
 	am, err := FindAll(albc, []*string{to.Strp("tg_name"), to.Strp("tg_other_name")})
 
 	assert.NoError(t, err)
@@ -36,7 +59,7 @@ func Test_FindAll_Found(t *testing.T) {
 
 func Test_GetInstances(t *testing.T) {
 	albc := &mocks.ALBClient{}
-	albc.AddTargetGroup("tg_name", "project_name", "config_name", "service_name")
+	albc.AddTargetGroup(mocks.MockTargetGroup{})
 
 	instances, err := GetInstances(albc, to.Strp("tg_name"), []string{"InstanceId"})
 	assert.NoError(t, err)

--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -45,6 +45,11 @@ func (s *ASG) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+// AllowedService returns which service is allowed to attach to it
+func (s *ASG) AllowedService() *string {
+	return to.Strp(fmt.Sprintf("%s::%s::%s", *s.ProjectName(), *s.ConfigName(), *s.ServiceName()))
+}
+
 // ReleaseID returns tag
 func (s *ASG) ReleaseID() *string {
 	if !is.EmptyStr(s.ReleaseIDTag) {

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -136,7 +136,7 @@ func HasServiceName(r interface {
 func MatchesAllowedService(r interface {
 	AllowedService() *string
 }, projectName *string, configName *string, serviceName *string) bool {
-	if r.AllowedService() == nil || projectName == nil || configName == nil || serviceName == nil {
+	if projectName == nil || configName == nil || serviceName == nil || r.AllowedService() == nil {
 		return false
 	}
 	return *r.AllowedService() == fmt.Sprintf("%s::%s::%s", *projectName, *configName, *serviceName)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -130,6 +131,15 @@ func HasServiceName(r interface {
 		return false
 	}
 	return *r.ServiceName() == *serviceName
+}
+
+func MatchesAllowedService(r interface {
+	AllowedService() *string
+}, projectName *string, configName *string, serviceName *string) bool {
+	if r.AllowedService() == nil || projectName == nil || configName == nil || serviceName == nil {
+		return false
+	}
+	return *r.AllowedService() == fmt.Sprintf("%s::%s::%s", *projectName, *configName, *serviceName)
 }
 
 // HasReleaseID checks value

--- a/aws/elb/elb.go
+++ b/aws/elb/elb.go
@@ -32,8 +32,14 @@ func (s *LoadBalancer) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+// Name returns tag
 func (s *LoadBalancer) Name() *string {
 	return s.LoadBalancerName
+}
+
+// AllowedService returns tag
+func (s *LoadBalancer) AllowedService() *string {
+	return to.Strp(fmt.Sprintf("%s::%s::%s", *s.ProjectName(), *s.ConfigName(), *s.ServiceName()))
 }
 
 ///////

--- a/aws/sg/security_group.go
+++ b/aws/sg/security_group.go
@@ -32,8 +32,14 @@ func (s *SecurityGroup) ServiceName() *string {
 	return s.ServiceNameTag
 }
 
+// Name returns tag
 func (s *SecurityGroup) Name() *string {
 	return s.NameTag
+}
+
+// AllowedService returns which service is allowed to attach to it
+func (s *SecurityGroup) AllowedService() *string {
+	return to.Strp(fmt.Sprintf("%s::%s::%s", *s.ProjectName(), *s.ConfigName(), *s.ServiceName()))
 }
 
 // Find returns the security groups with tags

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -38,7 +38,12 @@ func MockAwsClients(release *Release) *mocks.MockClients {
 		awsc.EC2.AddSubnet("private-subnet", "subnet-1")
 
 		awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
-		awsc.ALB.AddTargetGroup("web-elb-target", *release.ProjectName, *release.ConfigName, "web")
+		awsc.ALB.AddTargetGroup(mocks.MockTargetGroup{
+			Name:        "web-elb-target",
+			ProjectName: *release.ProjectName,
+			ConfigName:  *release.ConfigName,
+			ServiceName: "web",
+		})
 
 		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
 		awsc.IAM.AddGetRole("sns_role")

--- a/deployer/models/service_resources.go
+++ b/deployer/models/service_resources.go
@@ -27,6 +27,7 @@ type pcsresourceIface interface {
 	ProjectName() *string
 	ConfigName() *string
 	ServiceName() *string
+	AllowedService() *string
 	Name() *string
 }
 
@@ -305,6 +306,10 @@ func ValidateTargetGroup(service serviceIface, tg *alb.TargetGroup) error {
 func validateProjectConfigServiceNames(prefix string, service serviceIface, r pcsresourceIface) error {
 	if r == nil {
 		return fmt.Errorf("%v is nil", prefix)
+	}
+
+	if prefix == "TargetGroup" && aws.MatchesAllowedService(r, service.ProjectName(), service.ConfigName(), service.Name()) {
+		return nil
 	}
 
 	if !aws.HasProjectName(r, service.ProjectName()) && !aws.HasAllValue(r.ProjectName()) {


### PR DESCRIPTION
As we expand the use of target groups, we will likely want to deploy multiple projects behind a single ALB. To do this, we need to allow a target group to nominate the service that should be allowed to attach to it, if it differs from the parent project. 

We do this via an `AllowedService` tag on the target group.