### PR TITLE
[Feature] Safe Release

### DIFF
--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -80,6 +80,16 @@ func ValidateResources(awsc aws.Clients) DeployHandler {
 			return nil, &errors.BadReleaseError{err.Error()}
 		}
 
+		// If this flag is set Odin will fail a deploy if previous Release is dangerously different
+		if release.ForceSafeDeploy {
+			if err := release.ValidateSafeDeploy(
+				awsc.S3Client(release.AwsRegion, nil, nil),
+				resources,
+			); err != nil {
+				return nil, &errors.BadReleaseError{err.Error()}
+			}
+		}
+
 		release.UpdateWithResources(resources)
 
 		return release, nil

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -81,8 +81,8 @@ func ValidateResources(awsc aws.Clients) DeployHandler {
 		}
 
 		// If this flag is set Odin will fail a deploy if previous Release is dangerously different
-		if release.ForceSafeDeploy {
-			if err := release.ValidateSafeDeploy(
+		if release.SafeRelease {
+			if err := release.ValidateSafeRelease(
 				awsc.S3Client(release.AwsRegion, nil, nil),
 				resources,
 			); err != nil {

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -6,11 +6,17 @@ import (
 	"github.com/coinbase/odin/aws"
 	"github.com/coinbase/odin/deployer/models"
 	"github.com/coinbase/step/machine"
+	"github.com/coinbase/step/utils/to"
 	"github.com/stretchr/testify/assert"
 )
 
 func assertSuccessfulExecution(t *testing.T, release *models.Release) {
-	stateMachine := createTestStateMachine(t, models.MockAwsClients(release))
+	awsc := models.MockAwsClients(release)
+	stateMachine := createTestStateMachine(t, awsc)
+
+	previousRelease := models.MockRelease(t)
+	previousRelease.ReleaseID = to.Strp("old-release")
+	models.AddReleaseS3Objects(awsc, previousRelease)
 
 	exec, err := stateMachine.Execute(release)
 	output := exec.Output

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -1,14 +1,14 @@
 package models
 
 import (
-	"encoding/json"
-	"fmt"
-	"testing"
-	"time"
+  "encoding/json"
+  "fmt"
+  "testing"
+  "time"
 
-	"github.com/coinbase/odin/aws/mocks"
-	"github.com/coinbase/step/utils/to"
-	"github.com/stretchr/testify/assert"
+  "github.com/coinbase/odin/aws/mocks"
+  "github.com/coinbase/step/utils/to"
+  "github.com/stretchr/testify/assert"
 )
 
 //////////
@@ -17,54 +17,58 @@ import (
 
 // MockPrepareRelease mocks
 func MockPrepareRelease(release *Release) {
-	release.Release.SetDefaults(to.Strp("region"), to.Strp("account"), "")
-	release.SetDefaults()
-	if release.UserData() == nil {
-		release.SetUserData(to.Strp("#cloud_config"))
-	}
+  release.Release.SetDefaults(to.Strp("region"), to.Strp("account"), "")
+  release.SetDefaults()
+  if release.UserData() == nil {
+    release.SetUserData(to.Strp("#cloud_config"))
+  }
 
-	release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+  release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
 }
 
 // MockAwsClients mocks
 func MockAwsClients(release *Release) *mocks.MockClients {
-	awsc := mocks.MockAWS()
+  awsc := mocks.MockAWS()
 
-	if release.ProjectName != nil && release.ConfigName != nil {
-		awsc.ASG.AddPreviousRuntimeResources(*release.ProjectName, *release.ConfigName, "web", "old-release")
+  if release.ProjectName != nil && release.ConfigName != nil {
+    awsc.ASG.AddPreviousRuntimeResources(*release.ProjectName, *release.ConfigName, "web", "old-release")
 
-		awsc.EC2.AddSecurityGroup("web-sg", *release.ProjectName, *release.ConfigName, "web", nil)
-		awsc.EC2.AddImage("ubuntu", "ami-123456")
-		awsc.EC2.AddSubnet("private-subnet", "subnet-1")
+    awsc.EC2.AddSecurityGroup("web-sg", *release.ProjectName, *release.ConfigName, "web", nil)
+    awsc.EC2.AddImage("ubuntu", "ami-123456")
+    awsc.EC2.AddSubnet("private-subnet", "subnet-1")
 
-		awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
-		awsc.ALB.AddTargetGroup(mocks.MockTargetGroup{
-			Name:        "web-elb-target",
-			ProjectName: *release.ProjectName,
-			ConfigName:  *release.ConfigName,
-			ServiceName: "web",
-		})
+    awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
+    awsc.ALB.AddTargetGroup(mocks.MockTargetGroup{
+      Name:        "web-elb-target",
+      ProjectName: *release.ProjectName,
+      ConfigName:  *release.ConfigName,
+      ServiceName: "web",
+    })
 
-		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
-		awsc.IAM.AddGetRole("sns_role")
+    awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
+    awsc.IAM.AddGetRole("sns_role")
 
-		// Upload items to S3
-		if release.ReleaseID == nil {
-			release.ReleaseID = to.Strp("rr")
-		}
+    // Upload items to S3
+    if release.ReleaseID == nil {
+      release.ReleaseID = to.Strp("rr")
+    }
 
-		if release.UserData() == nil {
-			release.SetUserData(to.Strp("#cloud_config"))
-		}
+    addReleaseS3Objects(awsc, release)
+  }
 
-		awsc.S3.AddGetObject(*release.UserDataPath(), *release.UserData(), nil)
-		release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+  return awsc
+}
 
-		raw, _ := json.Marshal(release)
-		awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
-	}
+func addReleaseS3Objects(awsc *mocks.MockClients, release *Release) {
+  if release.UserData() == nil {
+    release.SetUserData(to.Strp("#cloud_config"))
+  }
 
-	return awsc
+  awsc.S3.AddGetObject(*release.UserDataPath(), *release.UserData(), nil)
+  release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+
+  raw, _ := json.Marshal(release)
+  awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
 }
 
 //////////
@@ -73,8 +77,8 @@ func MockAwsClients(release *Release) *mocks.MockClients {
 
 // MockMinimalRelease mocks
 func MockMinimalRelease(t *testing.T) *Release {
-	var r Release
-	err := json.Unmarshal([]byte(`
+  var r Release
+  err := json.Unmarshal([]byte(`
   {
     "aws_account_id": "000000",
     "release_id": "rr",
@@ -91,16 +95,16 @@ func MockMinimalRelease(t *testing.T) *Release {
   }
   `), &r)
 
-	assert.NoError(t, err)
-	r.CreatedAt = to.Timep(time.Now())
+  assert.NoError(t, err)
+  r.CreatedAt = to.Timep(time.Now())
 
-	return &r
+  return &r
 }
 
 // MockRelease mocks
 func MockRelease(t *testing.T) *Release {
-	var r Release
-	err := json.Unmarshal([]byte(`
+  var r Release
+  err := json.Unmarshal([]byte(`
   {
     "aws_account_id": "000000",
     "release_id": "1",
@@ -157,9 +161,9 @@ func MockRelease(t *testing.T) *Release {
   }
   `), &r)
 
-	assert.NoError(t, err)
+  assert.NoError(t, err)
 
-	r.CreatedAt = to.Timep(time.Now())
+  r.CreatedAt = to.Timep(time.Now())
 
-	return &r
+  return &r
 }

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -1,14 +1,14 @@
 package models
 
 import (
-  "encoding/json"
-  "fmt"
-  "testing"
-  "time"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
 
-  "github.com/coinbase/odin/aws/mocks"
-  "github.com/coinbase/step/utils/to"
-  "github.com/stretchr/testify/assert"
+	"github.com/coinbase/odin/aws/mocks"
+	"github.com/coinbase/step/utils/to"
+	"github.com/stretchr/testify/assert"
 )
 
 //////////
@@ -17,58 +17,58 @@ import (
 
 // MockPrepareRelease mocks
 func MockPrepareRelease(release *Release) {
-  release.Release.SetDefaults(to.Strp("region"), to.Strp("account"), "")
-  release.SetDefaults()
-  if release.UserData() == nil {
-    release.SetUserData(to.Strp("#cloud_config"))
-  }
+	release.Release.SetDefaults(to.Strp("region"), to.Strp("account"), "")
+	release.SetDefaults()
+	if release.UserData() == nil {
+		release.SetUserData(to.Strp("#cloud_config"))
+	}
 
-  release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+	release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
 }
 
 // MockAwsClients mocks
 func MockAwsClients(release *Release) *mocks.MockClients {
-  awsc := mocks.MockAWS()
+	awsc := mocks.MockAWS()
 
-  if release.ProjectName != nil && release.ConfigName != nil {
-    awsc.ASG.AddPreviousRuntimeResources(*release.ProjectName, *release.ConfigName, "web", "old-release")
+	if release.ProjectName != nil && release.ConfigName != nil {
+		awsc.ASG.AddPreviousRuntimeResources(*release.ProjectName, *release.ConfigName, "web", "old-release")
 
-    awsc.EC2.AddSecurityGroup("web-sg", *release.ProjectName, *release.ConfigName, "web", nil)
-    awsc.EC2.AddImage("ubuntu", "ami-123456")
-    awsc.EC2.AddSubnet("private-subnet", "subnet-1")
+		awsc.EC2.AddSecurityGroup("web-sg", *release.ProjectName, *release.ConfigName, "web", nil)
+		awsc.EC2.AddImage("ubuntu", "ami-123456")
+		awsc.EC2.AddSubnet("private-subnet", "subnet-1")
 
-    awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
-    awsc.ALB.AddTargetGroup(mocks.MockTargetGroup{
-      Name:        "web-elb-target",
-      ProjectName: *release.ProjectName,
-      ConfigName:  *release.ConfigName,
-      ServiceName: "web",
-    })
+		awsc.ELB.AddELB("web-elb", *release.ProjectName, *release.ConfigName, "web")
+		awsc.ALB.AddTargetGroup(mocks.MockTargetGroup{
+			Name:        "web-elb-target",
+			ProjectName: *release.ProjectName,
+			ConfigName:  *release.ConfigName,
+			ServiceName: "web",
+		})
 
-    awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
-    awsc.IAM.AddGetRole("sns_role")
+		awsc.IAM.AddGetInstanceProfile("web-profile", fmt.Sprintf("/odin/%v/%v/web/", *release.ProjectName, *release.ConfigName))
+		awsc.IAM.AddGetRole("sns_role")
 
-    // Upload items to S3
-    if release.ReleaseID == nil {
-      release.ReleaseID = to.Strp("rr")
-    }
+		// Upload items to S3
+		if release.ReleaseID == nil {
+			release.ReleaseID = to.Strp("rr")
+		}
 
-    addReleaseS3Objects(awsc, release)
-  }
+		AddReleaseS3Objects(awsc, release)
+	}
 
-  return awsc
+	return awsc
 }
 
-func addReleaseS3Objects(awsc *mocks.MockClients, release *Release) {
-  if release.UserData() == nil {
-    release.SetUserData(to.Strp("#cloud_config"))
-  }
+func AddReleaseS3Objects(awsc *mocks.MockClients, release *Release) {
+	if release.UserData() == nil {
+		release.SetUserData(to.Strp("#cloud_config"))
+	}
 
-  awsc.S3.AddGetObject(*release.UserDataPath(), *release.UserData(), nil)
-  release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
+	awsc.S3.AddGetObject(*release.UserDataPath(), *release.UserData(), nil)
+	release.UserDataSHA256 = to.Strp(to.SHA256Str(release.UserData()))
 
-  raw, _ := json.Marshal(release)
-  awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
+	raw, _ := json.Marshal(release)
+	awsc.S3.AddGetObject(*release.ReleasePath(), string(raw), nil)
 }
 
 //////////
@@ -77,8 +77,8 @@ func addReleaseS3Objects(awsc *mocks.MockClients, release *Release) {
 
 // MockMinimalRelease mocks
 func MockMinimalRelease(t *testing.T) *Release {
-  var r Release
-  err := json.Unmarshal([]byte(`
+	var r Release
+	err := json.Unmarshal([]byte(`
   {
     "aws_account_id": "000000",
     "release_id": "rr",
@@ -95,18 +95,19 @@ func MockMinimalRelease(t *testing.T) *Release {
   }
   `), &r)
 
-  assert.NoError(t, err)
-  r.CreatedAt = to.Timep(time.Now())
+	assert.NoError(t, err)
+	r.CreatedAt = to.Timep(time.Now())
 
-  return &r
+	return &r
 }
 
 // MockRelease mocks
 func MockRelease(t *testing.T) *Release {
-  var r Release
-  err := json.Unmarshal([]byte(`
+	var r Release
+	err := json.Unmarshal([]byte(`
   {
     "aws_account_id": "000000",
+    "aws_region": "us-east-1",
     "release_id": "1",
     "project_name": "project",
     "config_name": "config",
@@ -161,9 +162,9 @@ func MockRelease(t *testing.T) *Release {
   }
   `), &r)
 
-  assert.NoError(t, err)
+	assert.NoError(t, err)
 
-  r.CreatedAt = to.Timep(time.Now())
+	r.CreatedAt = to.Timep(time.Now())
 
-  return &r
+	return &r
 }

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -14,6 +14,8 @@ import (
 type Release struct {
 	bifrost.Release
 
+	ForceSafeDeploy bool `json:"force_safe_deploy,omitempty"`
+
 	Subnets []*string `json:"subnets,omitempty"`
 
 	Image *string `json:"ami,omitempty"`

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -70,6 +70,11 @@ func (release *Release) SetDefaultsWithUserData(s3c aws.S3API) error {
 func (release *Release) SetDefaults() {
 	// Overwrite WaitForHealthy to be Min 15 seconds, Max 5 minutes
 	waitForHealthy := 120
+
+	if release.Timeout == nil {
+		release.Timeout = to.Intp(600)
+	}
+
 	switch {
 	case *release.Timeout < 1800:
 		// Under 30 mins check every 15 seconds

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -14,7 +14,7 @@ import (
 type Release struct {
 	bifrost.Release
 
-	ForceSafeDeploy bool `json:"force_safe_deploy,omitempty"`
+	SafeRelease bool `json:"safe_release,omitempty"`
 
 	Subnets []*string `json:"subnets,omitempty"`
 
@@ -83,6 +83,10 @@ func (release *Release) SetDefaults() {
 
 	if release.Healthy == nil {
 		release.Healthy = to.Boolp(false)
+	}
+
+	if release.LifeCycleHooks == nil {
+		release.LifeCycleHooks = map[string]*LifeCycleHook{}
 	}
 
 	for name, lc := range release.LifeCycleHooks {

--- a/deployer/models/release_resources_test.go
+++ b/deployer/models/release_resources_test.go
@@ -13,10 +13,10 @@ func Test_Release_FetchResources_Works(t *testing.T) {
 
 	awsc := MockAwsClients(r)
 
-	sm, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS)
+	resources, err := r.FetchResources(awsc.ASG, awsc.EC2, awsc.ELB, awsc.ALB, awsc.IAM, awsc.SNS)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, len(sm))
+	assert.Equal(t, 1, len(resources.ServiceResources))
 }
 
 func Test_Release_ValidateResources_Works(t *testing.T) {

--- a/deployer/models/release_safe.go
+++ b/deployer/models/release_safe.go
@@ -66,15 +66,15 @@ func (release *Release) ValidateSafeRelease(s3c aws.S3API, resources *ReleaseRes
 func (release *Release) validateSafeRelease(previousRelease *Release) error {
 	// 1. Subnets, Image, or Services
 	if res := safeUnorderedStrList(release.Subnets, previousRelease.Subnets); res != nil {
-		return fmt.Errorf("SafeRelease Error: Subnets different %q", *res)
+		return fmt.Errorf("SafeRelease Error: Subnets different %v", *res)
 	}
 
 	if res := safeStr(release.Image, previousRelease.Image); res != nil {
-		return fmt.Errorf("SafeRelease Error: Image different %q", *res)
+		return fmt.Errorf("SafeRelease Error: Image different %v", *res)
 	}
 
 	if res := safeInt(release.Timeout, previousRelease.Timeout); res != nil {
-		return fmt.Errorf("SafeRelease Error: Timeout different %q", *res)
+		return fmt.Errorf("SafeRelease Error: Timeout different %v", *res)
 	}
 
 	if err := validateSafeServices(release.Services, previousRelease.Services); err != nil {
@@ -84,12 +84,9 @@ func (release *Release) validateSafeRelease(previousRelease *Release) error {
 	return nil
 }
 
-// TODO better
 func validateSafeServices(services map[string]*Service, prevServices map[string]*Service) error {
-
-	if len(services) != len(prevServices) {
-		// TODO better error message
-		return fmt.Errorf("Services incorrect")
+	if res := safeUnorderedStrList(serviceMapKeys(services), serviceMapKeys(prevServices)); res != nil {
+		return fmt.Errorf("SafeRelease Error: Incorrect Services service %v", *res)
 	}
 
 	for serviceName, service := range services {
@@ -111,43 +108,43 @@ func validaeSafeService(serviceName string, service *Service, prevService *Servi
 	// 2. Security Groups or Profile
 
 	if res := safeUnorderedStrList(service.SecurityGroups, prevService.SecurityGroups); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): SecurityGroups different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): SecurityGroups different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.Profile, prevService.Profile); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): Profile different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): Profile different %v", serviceName, *res)
 	}
 
 	// 3. ELBs or Target Groups
 	if res := safeUnorderedStrList(service.ELBs, prevService.ELBs); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): ELBs different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): ELBs different %v", serviceName, *res)
 	}
 
 	if res := safeUnorderedStrList(service.TargetGroups, prevService.TargetGroups); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): TargetGroups different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): TargetGroups different %v", serviceName, *res)
 	}
 
 	// 5. EBS information
 	if res := safeInt64(service.EBSVolumeSize, prevService.EBSVolumeSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeSize different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeSize different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.EBSVolumeType, prevService.EBSVolumeType); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeType different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeType different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.EBSDeviceName, prevService.EBSDeviceName); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSDeviceName different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): EBSDeviceName different %v", serviceName, *res)
 	}
 
 	// 6. AssociatePublicIpAddress
 	if res := safeBool(service.AssociatePublicIpAddress, prevService.AssociatePublicIpAddress); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): AssociatePublicIpAddress different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): AssociatePublicIpAddress different %v", serviceName, *res)
 	}
 
 	// 4. Instance Type
 	if res := safeStr(service.InstanceType, prevService.InstanceType); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): InstanceType different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): InstanceType different %v", serviceName, *res)
 	}
 
 	if err := validaeSafeAutoscaling(serviceName, service.Autoscaling, prevService.Autoscaling); err != nil {
@@ -159,30 +156,29 @@ func validaeSafeService(serviceName string, service *Service, prevService *Servi
 
 func validaeSafeAutoscaling(serviceName string, as *AutoScalingConfig, prevAs *AutoScalingConfig) error {
 	if res := safeInt64(as.MinSize, prevAs.MinSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MinSize different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): MinSize different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.MaxSize, prevAs.MaxSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MaxSize different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): MaxSize different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.MaxTerminations, prevAs.MaxTerminations); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MaxTerminations different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): MaxTerminations different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.DefaultCooldown, prevAs.DefaultCooldown); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): DefaultCooldown different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): DefaultCooldown different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.HealthCheckGracePeriod, prevAs.HealthCheckGracePeriod); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): HealthCheckGracePeriod different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): HealthCheckGracePeriod different %v", serviceName, *res)
 	}
 
 	if res := safeFloat64(as.Spread, prevAs.Spread); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): Spread different %q", serviceName, *res)
+		return fmt.Errorf("SafeRelease Error(%v): Spread different %v", serviceName, *res)
 	}
 
-	// TODO: add Policy checks
 	return nil
 }
 
@@ -292,7 +288,7 @@ func safeBool(s1 *bool, s2 *bool) *string {
 func safeUnorderedStrList(s1 []*string, s2 []*string) *string {
 	m1, ss1 := strS2Map(s1)
 	m2, ss2 := strS2Map(s2)
-	errStr := fmt.Sprintf(" previous release has %q, requested %q", ss2, ss1)
+	errStr := fmt.Sprintf("previous release has %v, requested %v", ss2, ss1)
 	if len(m1) != len(m2) {
 		return &errStr
 	}
@@ -305,6 +301,16 @@ func safeUnorderedStrList(s1 []*string, s2 []*string) *string {
 	}
 
 	return nil
+}
+
+func serviceMapKeys(sm map[string]*Service) []*string {
+	strSlice := []*string{}
+	for serviceName, _ := range sm {
+		// Maintain ref
+		a := serviceName
+		strSlice = append(strSlice, &a)
+	}
+	return strSlice
 }
 
 func strS2Map(slc []*string) (map[string]bool, []string) {

--- a/deployer/models/release_safe.go
+++ b/deployer/models/release_safe.go
@@ -1,0 +1,157 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/coinbase/step/aws"
+	"github.com/coinbase/step/aws/s3"
+	"github.com/coinbase/step/bifrost"
+)
+
+//////////
+// Safe Deploy
+//////////
+
+// ValidateSafeDeploy will error if the currently deployed release has different:
+// 1. Subnets, Image, or Services
+// Or any service has different:
+// 2. Security Groups or Profile
+// 3. ELBs or Target Groups
+// 4. Instance Type or Autoscaling Preferences
+// 5. EBS information
+// 6. AssociatePublicIpAddress
+func (release *Release) ValidateSafeDeploy(s3c aws.S3API, resources *ReleaseResources) error {
+	if len(resources.PreviousASGs) == 0 {
+		// If there are no currently deployed ASGs then we can ignore this check
+		return nil
+	}
+
+	// Scaffold Previous Release
+	previousRelease := Release{
+		Release: bifrost.Release{
+			ReleaseID:    resources.PreviousReleaseID,
+			ProjectName:  release.ProjectName,
+			ConfigName:   release.ConfigName,
+			AwsAccountID: release.AwsAccountID,
+			AwsRegion:    release.AwsRegion,
+			Bucket:       release.Bucket,
+		},
+	}
+
+	// Get Previous Release From S3
+	err := s3.GetStruct(
+		s3c,
+		previousRelease.Bucket,
+		previousRelease.ReleasePath(),
+		&previousRelease,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return release.validateSafeDeploy(&previousRelease)
+}
+
+func (release *Release) validateSafeDeploy(previousRelease *Release) error {
+	// 1. Subnets, Image, or Services
+	if !equalUnorderedStrList(release.Subnets, previousRelease.Subnets) {
+		return fmt.Errorf("SafeDeploy Error: Subnets different")
+	}
+
+	if !equalStr(release.Image, previousRelease.Image) {
+		return fmt.Errorf("SafeDeploy Error: Image different")
+	}
+
+	if err := safeServices(release.Services, previousRelease.Services); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TODO better
+func safeServices(services map[string]*Service, prevServices map[string]*Service) error {
+
+	if len(services) != len(prevServices) {
+		// TODO better error message
+		return fmt.Errorf("Services incorrect")
+	}
+
+	for serviceName, service := range services {
+		prevService, ok := prevServices[serviceName]
+		if !ok {
+			return false
+		}
+
+		if err := safeService(service, prevService); err != nil {
+			return err
+		}
+	}
+
+	return true
+}
+
+func safeService(service *Service, prevService *Service) error {
+	// 2. Security Groups or Profile
+	// 3. ELBs or Target Groups
+	// 4. Instance Type or Autoscaling Preferences
+	// 5. EBS information
+	// 6. AssociatePublicIpAddress
+	if !equalUnorderedStrList(service.SecurityGroups, prevService.SecurityGroups) {
+		return fmt.Errorf("SafeDeploy Error: SecurityGroups different")
+	}
+
+	if !equalUnorderedStrList(service.ELBs, prevService.ELBs) {
+		return fmt.Errorf("SafeDeploy Error: ELBs different")
+	}
+
+	if !equalUnorderedStrList(service.TargetGroups, prevService.TargetGroups) {
+		return fmt.Errorf("SafeDeploy Error: ELBs different")
+	}
+
+	return nil
+}
+
+////
+// Utils
+////
+func equalStr(s1 *string, s2 *string) bool {
+	if s1 == nil {
+		return false
+	}
+
+	if s2 == nil {
+		return false
+	}
+
+	return *s1 == *s2
+}
+
+func equalUnorderedStrList(s1 []*string, s2 []*string) bool {
+	m1 := strS2Map(s1)
+	m2 := strS2Map(s2)
+	if len(m1) != len(m2) {
+		return false
+	}
+
+	for s, _ := range m1 {
+		_, ok := m2[s]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func strS2Map(slc []*string) map[string]bool {
+	m := map[string]bool{}
+	for _, s := range slc {
+		if s == nil {
+			continue
+		}
+		m[*s] = true
+	}
+	return m
+}

--- a/deployer/models/release_safe.go
+++ b/deployer/models/release_safe.go
@@ -58,6 +58,7 @@ func (release *Release) ValidateSafeRelease(s3c aws.S3API, resources *ReleaseRes
 	}
 
 	// Set Defaults for comparison
+	previousRelease.Release.SetDefaults(release.AwsRegion, release.AwsAccountID, "coinbase-odin-")
 	previousRelease.SetDefaults()
 	return release.validateSafeRelease(&previousRelease)
 }

--- a/deployer/models/release_safe_test.go
+++ b/deployer/models/release_safe_test.go
@@ -49,6 +49,11 @@ func Test_Release_validateSafeRelease_Subnet_Image(t *testing.T) {
 	release.Image = to.Strp("not_image")
 
 	validateSafeErrorTest(t, release, "Image")
+
+	release = MockRelease(t)
+	release.Services = map[string]*Service{}
+
+	validateSafeErrorTest(t, release, "Services")
 }
 
 func Test_Release_validateSafeRelease_Service(t *testing.T) {
@@ -89,6 +94,17 @@ func Test_Release_validateSafeRelease_Autoscaling(t *testing.T) {
 	release.Services["web"].Autoscaling.MinSize = to.Int64p(64)
 
 	validateSafeErrorTest(t, release, "MinSize")
+}
+
+func Test_Release_safe_serviceMapKeys(t *testing.T) {
+	// ELB
+	s := serviceMapKeys(map[string]*Service{"web": nil, "angry": nil})
+	// Convert to string slice
+	ss := to.StrSlice(s)
+
+	assert.Equal(t, len(ss), 2)
+	assert.Contains(t, ss, "web")
+	assert.Contains(t, ss, "angry")
 }
 
 // Test Util

--- a/deployer/models/release_safe_test.go
+++ b/deployer/models/release_safe_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/coinbase/odin/aws/asg"
+	"github.com/coinbase/step/utils/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Release_ValidateSafeDeploy_Works(t *testing.T) {
+	release := MockRelease(t)
+	MockPrepareRelease(release)
+
+	awsc := MockAwsClients(release)
+
+	previousRelease := MockRelease(t)
+	previousRelease.ReleaseID = to.Strp("prevReleaseID")
+
+	// Add release to S3 Mock
+	addReleaseS3Objects(awsc, previousRelease)
+
+	err := release.ValidateSafeDeploy(awsc.S3, &ReleaseResources{
+		PreviousReleaseID: previousRelease.ReleaseID,
+		PreviousASGs:      map[string]*asg.ASG{"a": nil},
+		ServiceResources:  map[string]*ServiceResources{"a": nil},
+	})
+
+	assert.NoError(t, err)
+}
+
+func Test_Release_validateSafeDeploy_Works(t *testing.T) {
+	release := MockRelease(t)
+	previousRelease := MockRelease(t)
+
+	err := release.validateSafeDeploy(previousRelease)
+	assert.NoError(t, err)
+}
+
+func Test_Release_validateSafeDeploy_SubnetErrors(t *testing.T) {
+	release := MockRelease(t)
+	release.Subnets = []*string{to.Strp("not")}
+
+	previousRelease := MockRelease(t)
+
+	err := release.validateSafeDeploy(previousRelease)
+	assert.Error(t, err)
+	assert.Regexp(t, "Subnet", err.Error())
+}
+
+func Test_Release_validateSafeDeploy_ImageErrors(t *testing.T) {
+	release := MockRelease(t)
+	release.Image = to.Strp("not_image")
+
+	previousRelease := MockRelease(t)
+
+	err := release.validateSafeDeploy(previousRelease)
+	assert.Error(t, err)
+	assert.Regexp(t, "Image", err.Error())
+}


### PR DESCRIPTION
Safe Release flag `safe_release ` is used to compare the previous release for dangerous changes and fail the deploy if such a change is detected.

This is backwards compatible because the flag is defaulted to false and no new validations are added without the new flag set true.
