### PR TITLE
[Fix] remove image from safety checks, increase ALB timeout

### DIFF
--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -158,7 +158,7 @@ func StateMachine() (*machine.StateMachine, error) {
       "WaitDetachForSuccess": {
         "Comment": "Give detach a little time to do what it does",
         "Type": "Wait",
-        "Seconds" : 10,
+        "Seconds" : 20,
         "Next": "CleanUpSuccess"
       },
       "CleanUpSuccess": {

--- a/deployer/models/release_safe.go
+++ b/deployer/models/release_safe.go
@@ -14,7 +14,7 @@ import (
 //////////
 
 // ValidateSafeRelease will error if the currently deployed release has different:
-// 1. Subnets, Image, or Services
+// 1. Subnets, or Services
 // Or any service has different:
 // 2. Security Groups or Profile
 // 3. ELBs or Target Groups
@@ -64,13 +64,9 @@ func (release *Release) ValidateSafeRelease(s3c aws.S3API, resources *ReleaseRes
 }
 
 func (release *Release) validateSafeRelease(previousRelease *Release) error {
-	// 1. Subnets, Image, or Services
+	// 1. Subnets, or Services
 	if res := safeUnorderedStrList(release.Subnets, previousRelease.Subnets); res != nil {
 		return fmt.Errorf("SafeRelease Error: Subnets different %v", *res)
-	}
-
-	if res := safeStr(release.Image, previousRelease.Image); res != nil {
-		return fmt.Errorf("SafeRelease Error: Image different %v", *res)
 	}
 
 	if res := safeInt(release.Timeout, previousRelease.Timeout); res != nil {

--- a/deployer/models/release_safe_test.go
+++ b/deployer/models/release_safe_test.go
@@ -44,12 +44,6 @@ func Test_Release_validateSafeRelease_Subnet_Image(t *testing.T) {
 
 	validateSafeErrorTest(t, release, "Subnet")
 
-	// Image
-	release = MockRelease(t)
-	release.Image = to.Strp("not_image")
-
-	validateSafeErrorTest(t, release, "Image")
-
 	release = MockRelease(t)
 	release.Services = map[string]*Service{}
 


### PR DESCRIPTION
CLOUD-671 & DEVPROD-664
This PR:
1. removes image from safety checks to quickly allow security updates.
2. increases wait time after disconnect.

