### PR TITLE
[Fix] returning all safe_release errors at the same time

### DIFF
--- a/deployer/models/release_safe.go
+++ b/deployer/models/release_safe.go
@@ -60,122 +60,194 @@ func (release *Release) ValidateSafeRelease(s3c aws.S3API, resources *ReleaseRes
 	// Set Defaults for comparison
 	previousRelease.Release.SetDefaults(release.AwsRegion, release.AwsAccountID, "coinbase-odin-")
 	previousRelease.SetDefaults()
+
+	// return an error for valid services
 	return release.validateSafeRelease(&previousRelease)
 }
 
+type SafeReleaseError struct {
+	Subnets        error
+	Timeout        error
+	AllServices    error
+	MissingService error
+
+	Services map[string]*SafeReleaseServiceError
+}
+
+type SafeReleaseServiceError struct {
+	SecurityGroups           error
+	Profile                  error
+	ELBs                     error
+	TargetGroups             error
+	EBSVolumeSize            error
+	EBSVolumeType            error
+	EBSDeviceName            error
+	AssociatePublicIpAddress error
+	InstanceType             error
+	MinSize                  error
+	MaxSize                  error
+	MaxTerminations          error
+	DefaultCooldown          error
+	HealthCheckGracePeriod   error
+	Spread                   error
+}
+
+// Prints the list of safe release errors
+func (sre *SafeReleaseError) Error() string {
+	errstr := ""
+	errstr = appendError(errstr, sre.Subnets)
+	errstr = appendError(errstr, sre.Timeout)
+	errstr = appendError(errstr, sre.AllServices)
+	errstr = appendError(errstr, sre.MissingService)
+	for _, srse := range sre.Services {
+		errstr = appendError(errstr, srse.SecurityGroups)
+		errstr = appendError(errstr, srse.Profile)
+		errstr = appendError(errstr, srse.ELBs)
+		errstr = appendError(errstr, srse.TargetGroups)
+		errstr = appendError(errstr, srse.EBSVolumeSize)
+		errstr = appendError(errstr, srse.EBSVolumeType)
+		errstr = appendError(errstr, srse.EBSDeviceName)
+		errstr = appendError(errstr, srse.AssociatePublicIpAddress)
+		errstr = appendError(errstr, srse.InstanceType)
+		errstr = appendError(errstr, srse.MinSize)
+		errstr = appendError(errstr, srse.MaxSize)
+		errstr = appendError(errstr, srse.MaxTerminations)
+		errstr = appendError(errstr, srse.DefaultCooldown)
+		errstr = appendError(errstr, srse.HealthCheckGracePeriod)
+		errstr = appendError(errstr, srse.Spread)
+	}
+
+	return errstr
+}
+
+func appendError(errstr string, err error) string {
+	if err != nil {
+		errstr = fmt.Sprintf("%s\n%s", errstr, err.Error())
+	}
+
+	return errstr
+}
+
+// Returns nil if there is no error contained
+func (sre *SafeReleaseError) IsError() error {
+	if sre.Error() == "" {
+		return nil
+	}
+
+	return sre
+}
+
 func (release *Release) validateSafeRelease(previousRelease *Release) error {
+	sre := &SafeReleaseError{
+		Services: map[string]*SafeReleaseServiceError{},
+	}
+
 	// 1. Subnets, or Services
 	if res := safeUnorderedStrList(release.Subnets, previousRelease.Subnets); res != nil {
-		return fmt.Errorf("SafeRelease Error: Subnets different %v", *res)
+		sre.Subnets = fmt.Errorf("SafeRelease Error: Subnets different %v", *res)
 	}
 
 	if res := safeInt(release.Timeout, previousRelease.Timeout); res != nil {
-		return fmt.Errorf("SafeRelease Error: Timeout different %v", *res)
+		sre.Timeout = fmt.Errorf("SafeRelease Error: Timeout different %v", *res)
 	}
 
-	if err := validateSafeServices(release.Services, previousRelease.Services); err != nil {
-		return err
-	}
+	// This will add errors to the sre
+	validateSafeServices(sre, release.Services, previousRelease.Services)
 
-	return nil
+	// Check whether an error was found and return if it has
+	return sre.IsError()
 }
 
-func validateSafeServices(services map[string]*Service, prevServices map[string]*Service) error {
+func validateSafeServices(sre *SafeReleaseError, services map[string]*Service, prevServices map[string]*Service) {
 	if res := safeUnorderedStrList(serviceMapKeys(services), serviceMapKeys(prevServices)); res != nil {
-		return fmt.Errorf("SafeRelease Error: Incorrect Services service %v", *res)
+		sre.AllServices = fmt.Errorf("SafeRelease Error: Incorrect Services service %v", *res)
 	}
 
 	for serviceName, service := range services {
 		prevService, ok := prevServices[serviceName]
 
 		if !ok {
-			return fmt.Errorf("SafeRelease Error(%v): No previous service", serviceName)
+			// Pretty sure this will never be reached (best check though)
+			sre.MissingService = fmt.Errorf("SafeRelease Error(%v): No previous service", serviceName)
 		}
 
-		if err := validaeSafeService(serviceName, service, prevService); err != nil {
-			return err
-		}
+		sre.Services[serviceName] = validaeSafeService(serviceName, service, prevService)
 	}
-
-	return nil
 }
 
-func validaeSafeService(serviceName string, service *Service, prevService *Service) error {
+func validaeSafeService(serviceName string, service *Service, prevService *Service) *SafeReleaseServiceError {
+	srse := &SafeReleaseServiceError{}
 	// 2. Security Groups or Profile
 
 	if res := safeUnorderedStrList(service.SecurityGroups, prevService.SecurityGroups); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): SecurityGroups different %v", serviceName, *res)
+		srse.SecurityGroups = fmt.Errorf("SafeRelease Error(%v): SecurityGroups different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.Profile, prevService.Profile); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): Profile different %v", serviceName, *res)
+		srse.Profile = fmt.Errorf("SafeRelease Error(%v): Profile different %v", serviceName, *res)
 	}
 
 	// 3. ELBs or Target Groups
 	if res := safeUnorderedStrList(service.ELBs, prevService.ELBs); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): ELBs different %v", serviceName, *res)
+		srse.ELBs = fmt.Errorf("SafeRelease Error(%v): ELBs different %v", serviceName, *res)
 	}
 
 	if res := safeUnorderedStrList(service.TargetGroups, prevService.TargetGroups); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): TargetGroups different %v", serviceName, *res)
+		srse.TargetGroups = fmt.Errorf("SafeRelease Error(%v): TargetGroups different %v", serviceName, *res)
 	}
 
 	// 5. EBS information
 	if res := safeInt64(service.EBSVolumeSize, prevService.EBSVolumeSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeSize different %v", serviceName, *res)
+		srse.EBSVolumeSize = fmt.Errorf("SafeRelease Error(%v): EBSVolumeSize different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.EBSVolumeType, prevService.EBSVolumeType); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSVolumeType different %v", serviceName, *res)
+		srse.EBSVolumeType = fmt.Errorf("SafeRelease Error(%v): EBSVolumeType different %v", serviceName, *res)
 	}
 
 	if res := safeStr(service.EBSDeviceName, prevService.EBSDeviceName); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): EBSDeviceName different %v", serviceName, *res)
+		srse.EBSDeviceName = fmt.Errorf("SafeRelease Error(%v): EBSDeviceName different %v", serviceName, *res)
 	}
 
 	// 6. AssociatePublicIpAddress
 	if res := safeBool(service.AssociatePublicIpAddress, prevService.AssociatePublicIpAddress); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): AssociatePublicIpAddress different %v", serviceName, *res)
+		srse.AssociatePublicIpAddress = fmt.Errorf("SafeRelease Error(%v): AssociatePublicIpAddress different %v", serviceName, *res)
 	}
 
 	// 4. Instance Type
 	if res := safeStr(service.InstanceType, prevService.InstanceType); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): InstanceType different %v", serviceName, *res)
+		srse.InstanceType = fmt.Errorf("SafeRelease Error(%v): InstanceType different %v", serviceName, *res)
 	}
 
-	if err := validaeSafeAutoscaling(serviceName, service.Autoscaling, prevService.Autoscaling); err != nil {
-		return err
-	}
+	validaeSafeAutoscaling(srse, serviceName, service.Autoscaling, prevService.Autoscaling)
 
-	return nil
+	return srse
 }
 
-func validaeSafeAutoscaling(serviceName string, as *AutoScalingConfig, prevAs *AutoScalingConfig) error {
+func validaeSafeAutoscaling(srse *SafeReleaseServiceError, serviceName string, as *AutoScalingConfig, prevAs *AutoScalingConfig) {
 	if res := safeInt64(as.MinSize, prevAs.MinSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MinSize different %v", serviceName, *res)
+		srse.MinSize = fmt.Errorf("SafeRelease Error(%v): MinSize different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.MaxSize, prevAs.MaxSize); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MaxSize different %v", serviceName, *res)
+		srse.MaxSize = fmt.Errorf("SafeRelease Error(%v): MaxSize different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.MaxTerminations, prevAs.MaxTerminations); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): MaxTerminations different %v", serviceName, *res)
+		srse.MaxTerminations = fmt.Errorf("SafeRelease Error(%v): MaxTerminations different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.DefaultCooldown, prevAs.DefaultCooldown); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): DefaultCooldown different %v", serviceName, *res)
+		srse.DefaultCooldown = fmt.Errorf("SafeRelease Error(%v): DefaultCooldown different %v", serviceName, *res)
 	}
 
 	if res := safeInt64(as.HealthCheckGracePeriod, prevAs.HealthCheckGracePeriod); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): HealthCheckGracePeriod different %v", serviceName, *res)
+		srse.HealthCheckGracePeriod = fmt.Errorf("SafeRelease Error(%v): HealthCheckGracePeriod different %v", serviceName, *res)
 	}
 
 	if res := safeFloat64(as.Spread, prevAs.Spread); res != nil {
-		return fmt.Errorf("SafeRelease Error(%v): Spread different %v", serviceName, *res)
+		srse.Spread = fmt.Errorf("SafeRelease Error(%v): Spread different %v", serviceName, *res)
 	}
-
-	return nil
 }
 
 ////

--- a/scripts/bootstrap_deployer
+++ b/scripts/bootstrap_deployer
@@ -3,16 +3,18 @@
 # assume-role to the correct account
 set -e
 
-go build . # Build for your operating system
-go install
-
 ./scripts/build_lambda_zip
 
+PROJECT_NAME=${PROJECT_NAME:-coinbase/odin}
+STEP_NAME=$(echo $PROJECT_NAME | sed 's/\//\-/')
+echo $PROJECT_NAME
+echo $STEP_NAME
+
 step bootstrap                         \
-  -lambda "coinbase-odin" \
-  -step "coinbase-odin"   \
-  -states "$(odin json)"\
-  -project "coinbase/odin"\
+  -lambda  $STEP_NAME    \
+  -step    $STEP_NAME    \
+  -states "$(go run odin.go json)" \
+  -project $PROJECT_NAME \
   -config "development"
 
 rm lambda.zip


### PR DESCRIPTION
Appending all `safe_release` errors together so that all issues can be addressed at once rather than iteratively over multiple failed deploys. 