### PR TITLE
[Fix] issue with detecting detached.

### DIFF
--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -270,13 +270,9 @@ func (s *ASG) Detach(asgc aws.ASGAPI) error {
 	return nil
 }
 
+// IsDetached only checks the
 func (s *ASG) IsDetached(asgc aws.ASGAPI) (bool, error) {
-	// No LBs? Skip!
-	if len(s.LoadBalancerNames) == 0 && len(s.TargetGroupARNs) == 0 {
-		return true, nil
-	}
-
-	removed := true
+	detached := true
 
 	states, err := asgc.DescribeLoadBalancerTargetGroups(&autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: s.ServiceID(),
@@ -292,10 +288,10 @@ func (s *ASG) IsDetached(asgc aws.ASGAPI) (bool, error) {
 	}
 
 	for _, targetGroup := range states.LoadBalancerTargetGroups {
-		removed = removed && (*targetGroup.State == "Removed")
+		detached = detached && (*targetGroup.State == "Removed")
 	}
 
-	return removed, nil
+	return detached, nil
 }
 
 // Teardown deletes the ASG with launch config and alarms

--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -270,7 +270,7 @@ func (s *ASG) Detach(asgc aws.ASGAPI) error {
 	return nil
 }
 
-// IsDetached only checks the
+// IsDetached only checks target groups at the moment
 func (s *ASG) IsDetached(asgc aws.ASGAPI) (bool, error) {
 	detached := true
 

--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -186,7 +186,7 @@ func StateMachine() (*machine.StateMachine, error) {
         "Retry": [{
           "Comment": "Retry on Detach Error",
           "ErrorEquals": ["DetachError"],
-          "MaxAttempts": 10,
+          "MaxAttempts": 30,
           "IntervalSeconds": 30
          },{
           "Comment": "Keep trying to Clean",

--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -158,7 +158,7 @@ func StateMachine() (*machine.StateMachine, error) {
       "WaitDetachForSuccess": {
         "Comment": "Give detach a little time to do what it does",
         "Type": "Wait",
-        "SecondsPath" : "$.wait_for_detach",
+        "Seconds" : 5,
         "Next": "CleanUpSuccess"
       },
       "CleanUpSuccess": {
@@ -204,7 +204,7 @@ func StateMachine() (*machine.StateMachine, error) {
       "WaitDetachForFailure": {
         "Comment": "Give detach a little time to do what it does",
         "Type": "Wait",
-        "Seconds" : 10,
+        "Seconds" : 5,
         "Next": "CleanUpFailure"
       },
       "CleanUpFailure": {

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -88,8 +88,8 @@ func (release *Release) SetDefaults() {
 	release.WaitForHealthy = to.Intp(waitForHealthy)
 
 	// Default to 20 if WaitForDetach
-	if release.WaitForDetach == nil || *release.WaitForDetach < 10 {
-		release.WaitForDetach = to.Intp(20)
+	if release.WaitForDetach == nil || *release.WaitForDetach < 5 {
+		release.WaitForDetach = to.Intp(10)
 	}
 
 	if release.Healthy == nil {

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -30,10 +30,12 @@ type Release struct {
 	Healthy *bool `json:"healthy,omitempty"`
 
 	WaitForHealthy *int `json:"wait_for_healthy,omitempty"`
-	WaitForDetach  *int `json:"wait_for_detach,omitempty"`
 
 	// AWS Service is Downloaded
 	Services map[string]*Service `json:"services,omitempty"` // Downloaded From S3
+
+	// DEPRECATED: leave for backwards compatability
+	WaitForDetach *int `json:"wait_for_detach,omitempty"`
 }
 
 //////////
@@ -86,11 +88,6 @@ func (release *Release) SetDefaults() {
 	}
 
 	release.WaitForHealthy = to.Intp(waitForHealthy)
-
-	// Default to 20 if WaitForDetach
-	if release.WaitForDetach == nil || *release.WaitForDetach < 5 {
-		release.WaitForDetach = to.Intp(10)
-	}
 
 	if release.Healthy == nil {
 		release.Healthy = to.Boolp(false)

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -317,6 +317,7 @@ func DetachAllASGs(asgc aws.ASGAPI, asgs []*asg.ASG) error {
 		if err != nil {
 			return err
 		}
+
 		if !d {
 			return DetachError{fmt.Sprintf("asg %s not detached", *asg.ServiceID())}
 		}


### PR DESCRIPTION
Due to checking a performance optimisation we never actually were checking if the instances were detached. This PR fixes that and ensures that the instances are detached. 

This could increase deploy times significanty, at least by the `deregistration_delay` amount, which by default is 300. So all deploys that have a target group may increase by up to 5 minutes.