### PR TITLE
[Fix] Also checking ELBs for detached and better error reporting

### DIFF
--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -270,28 +270,67 @@ func (s *ASG) Detach(asgc aws.ASGAPI) error {
 	return nil
 }
 
-// IsDetached only checks target groups at the moment
-func (s *ASG) IsDetached(asgc aws.ASGAPI) (bool, error) {
-	detached := true
+func (s *ASG) AttachedLBs(asgc aws.ASGAPI) ([]string, error) {
+	lbs := []string{}
+
+	tgs, err := s.attachedTargetGroups(asgc)
+	if err != nil {
+		return lbs, err
+	}
+
+	clbs, err := s.attachedClassicLBs(asgc)
+	if err != nil {
+		return lbs, err
+	}
+
+	lbs = append(lbs, tgs...)
+	lbs = append(lbs, clbs...)
+
+	return lbs, err
+}
+
+func (s *ASG) attachedTargetGroups(asgc aws.ASGAPI) ([]string, error) {
+	lbs := []string{}
 
 	states, err := asgc.DescribeLoadBalancerTargetGroups(&autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: s.ServiceID(),
 	})
 
 	if err != nil {
-		return false, err
-	}
-
-	// No LBs? Skip!
-	if len(states.LoadBalancerTargetGroups) == 0 {
-		return true, nil
+		return lbs, err
 	}
 
 	for _, targetGroup := range states.LoadBalancerTargetGroups {
-		detached = detached && (*targetGroup.State == "Removed")
+		if *targetGroup.State == "Removed" {
+			continue
+		}
+
+		lbs = append(lbs, *targetGroup.LoadBalancerTargetGroupARN)
 	}
 
-	return detached, nil
+	return lbs, nil
+}
+
+func (s *ASG) attachedClassicLBs(asgc aws.ASGAPI) ([]string, error) {
+	lbs := []string{}
+
+	states, err := asgc.DescribeLoadBalancers(&autoscaling.DescribeLoadBalancersInput{
+		AutoScalingGroupName: s.ServiceID(),
+	})
+
+	if err != nil {
+		return lbs, err
+	}
+
+	for _, lb := range states.LoadBalancers {
+		if *lb.State == "Removed" {
+			continue
+		}
+
+		lbs = append(lbs, *lb.LoadBalancerName)
+	}
+
+	return lbs, nil
 }
 
 // Teardown deletes the ASG with launch config and alarms

--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -34,6 +34,7 @@ type ASGClient struct {
 	DescribePoliciesResp              map[string]*DescribePoliciesResponse
 
 	DescribeLoadBalancerTargetGroupsOutput *autoscaling.DescribeLoadBalancerTargetGroupsOutput
+	DescribeLoadBalancersOutput            *autoscaling.DescribeLoadBalancersOutput
 }
 
 func (m *ASGClient) init() {
@@ -236,4 +237,11 @@ func (m *ASGClient) DescribeLoadBalancerTargetGroups(input *autoscaling.Describe
 		return m.DescribeLoadBalancerTargetGroupsOutput, nil
 	}
 	return &autoscaling.DescribeLoadBalancerTargetGroupsOutput{}, nil
+}
+
+func (m *ASGClient) DescribeLoadBalancers(input *autoscaling.DescribeLoadBalancersInput) (*autoscaling.DescribeLoadBalancersOutput, error) {
+	if m.DescribeLoadBalancersOutput != nil {
+		return m.DescribeLoadBalancersOutput, nil
+	}
+	return &autoscaling.DescribeLoadBalancersOutput{}, nil
 }

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -313,13 +313,13 @@ func DetachAllASGs(asgc aws.ASGAPI, asgs []*asg.ASG) error {
 	}
 
 	for _, asg := range asgs {
-		d, err := asg.IsDetached(asgc)
+		attachedLBs, err := asg.AttachedLBs(asgc)
 		if err != nil {
 			return err
 		}
 
-		if !d {
-			return DetachError{fmt.Sprintf("asg %s not detached", *asg.ServiceID())}
+		if len(attachedLBs) != 0 {
+			return DetachError{fmt.Sprintf("asg %s not detached with lbs %s", *asg.ServiceID(), attachedLBs)}
 		}
 	}
 


### PR DESCRIPTION
This PR:
1. Adds ELB checking for detached before finishing the deploy
2. Reports in the returned error the Actual ELBs which are not being removed.
