### PR TITLE
[Fix] Blunt fix to increase initial wait time to allow instance to self terminate

### DIFF
--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -84,7 +84,7 @@ func StateMachine() (*machine.StateMachine, error) {
       "WaitForDeploy": {
         "Comment": "Give the Deploy time to boot instances",
         "Type": "Wait",
-        "Seconds" : 30,
+        "Seconds" : 90,
         "Next": "WaitForHealthy"
       },
       "WaitForHealthy": {


### PR DESCRIPTION
When an ASG is set to EC2 health checks, its instances only check is that the instance is running. If it has a longer boot time Odin may succeed a deploy before the instance has a chance to shutdown because of bad userdata.

Long term Odin should should respect the HealthCheckGracePeriod for each instance (When EC2 health checks are there) but at the moment this is a blunt fix for now. 