### PR TITLE
[Feature] Create/Use placement groups for deploys.

### DIFF
--- a/aws/mocks/mock_ec2.go
+++ b/aws/mocks/mock_ec2.go
@@ -32,11 +32,15 @@ type EC2Client struct {
 	DescribeSecurityGroupsResp map[string]*DescribeSecurityGroupsResponse
 	DescribeSubnetsResp        *DescribeSubnetsResponse
 	DescribeImagesResp         *DescribeImagesResponse
+	PlacementGroups            []*ec2.PlacementGroup
 }
 
 func (m *EC2Client) init() {
 	if m.DescribeSecurityGroupsResp == nil {
 		m.DescribeSecurityGroupsResp = map[string]*DescribeSecurityGroupsResponse{}
+	}
+	if m.PlacementGroups == nil {
+		m.PlacementGroups = []*ec2.PlacementGroup{}
 	}
 }
 
@@ -127,4 +131,23 @@ func (m *EC2Client) DescribeImages(in *ec2.DescribeImagesInput) (*ec2.DescribeIm
 	}
 
 	return m.DescribeImagesResp.Resp, m.DescribeImagesResp.Error
+}
+
+func (m *EC2Client) DescribePlacementGroups(in *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
+	m.init()
+	return &ec2.DescribePlacementGroupsOutput{
+		PlacementGroups: m.PlacementGroups,
+	}, nil
+}
+
+func (m *EC2Client) CreatePlacementGroup(in *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
+	m.init()
+	m.PlacementGroups = append(m.PlacementGroups, &ec2.PlacementGroup{
+		GroupName:      in.GroupName,
+		PartitionCount: in.PartitionCount,
+		Strategy:       in.Strategy,
+		State:          to.Strp("available"),
+	})
+
+	return nil, nil
 }

--- a/aws/pg/placement_group.go
+++ b/aws/pg/placement_group.go
@@ -1,0 +1,97 @@
+package pg
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/coinbase/odin/aws"
+	"github.com/coinbase/step/utils/to"
+)
+
+// FindOrCreatePartitionGroup will find a partition group by name.
+// If it doenst exist:
+// - It will create one with the provided detail (error if detail is nil)
+// If one does exist:
+// - It will fetch that Partition Group and Error if any provided detail is missing
+func FindOrCreatePartitionGroup(ec2c aws.EC2API, groupName *string, partitionCount *int64, strategy *string) error {
+	if groupName == nil {
+		return fmt.Errorf("PlacementGroupError: groupName nil")
+	}
+
+	pg, err := findPlacementGroup(ec2c, groupName)
+	if err != nil {
+		return err
+	}
+
+	// If no pg is found create a new one
+	// otherwise validate that the found one equals the correct values
+	if pg == nil {
+		return createNewPlacementGroup(ec2c, groupName, partitionCount, strategy)
+	}
+
+	return validatePlacementGroup(pg, groupName, partitionCount, strategy)
+}
+
+// findPlacementGroup will search for a placement group, if none are found it will return (nil, nil)
+func findPlacementGroup(ec2c aws.EC2API, groupName *string) (*ec2.PlacementGroup, error) {
+	out, err := ec2c.DescribePlacementGroups(&ec2.DescribePlacementGroupsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   to.Strp("group-name"),
+				Values: []*string{groupName},
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, checkPG := range out.PlacementGroups {
+		if to.Strs(checkPG.GroupName) == to.Strs(groupName) {
+			return checkPG, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func createNewPlacementGroup(ec2c aws.EC2API, groupName *string, partitionCount *int64, strategy *string) error {
+	_, err := ec2c.CreatePlacementGroup(&ec2.CreatePlacementGroupInput{
+		GroupName:      groupName,
+		PartitionCount: partitionCount,
+		Strategy:       strategy,
+	})
+	return err
+}
+
+func validatePlacementGroup(pg *ec2.PlacementGroup, groupName *string, partitionCount *int64, strategy *string) error {
+	// pending | available | deleting | deleted
+	if to.Strs(pg.State) != "available" {
+		return fmt.Errorf("PlacementGroupError(%s): PG in invalid state %s", to.Strs(groupName), to.Strs(pg.State))
+	}
+
+	if to.Strs(groupName) != to.Strs(pg.GroupName) {
+		return fmt.Errorf("PlacementGroupError(%s): PG in invalid name %s", to.Strs(groupName), to.Strs(pg.GroupName))
+	}
+
+	if to.Strs(strategy) != to.Strs(pg.Strategy) {
+		return fmt.Errorf("PlacementGroupError(%s): PG in invalid strategy expected %s, got %s", to.Strs(groupName), to.Strs(pg.Strategy), to.Strs(strategy))
+	}
+
+	// Partition count should be equal only if strategy is 'partition'
+	if *strategy != "partition" {
+		return nil
+	}
+
+	if partitionCount == nil || pg.PartitionCount == nil {
+		// We should never get here, but checking is easy
+		return fmt.Errorf("PlacementGroupError(%s): PG has nil PartitionCount", to.Strs(groupName))
+	}
+
+	if *partitionCount != *pg.PartitionCount {
+		return fmt.Errorf("PlacementGroupError(%s): PG in invalid strategy expected %q, got %q", to.Strs(groupName), *pg.PartitionCount, *partitionCount)
+	}
+
+	return nil
+}

--- a/aws/pg/placement_group_test.go
+++ b/aws/pg/placement_group_test.go
@@ -14,14 +14,17 @@ func Test_FindOrCreatePartitionGroup(t *testing.T) {
 	ec2c := &mocks.EC2Client{}
 
 	// This will creates a placement group
-	err := FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("cluster"))
+	err := FindOrCreatePartitionGroup(ec2c, "i/i", to.Strp("i/i/groupName"), to.Int64p(10), to.Strp("cluster"))
 	assert.NoError(t, err)
 
 	// Finds the already created group
-	err = FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("cluster"))
+	err = FindOrCreatePartitionGroup(ec2c, "i/i", to.Strp("i/i/groupName"), to.Int64p(10), to.Strp("cluster"))
 	assert.NoError(t, err)
 
 	// This will error because the strategy is incorrect
-	err = FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("wrong_stratgy"))
+	err = FindOrCreatePartitionGroup(ec2c, "i/i", to.Strp("i/i/groupName"), to.Int64p(10), to.Strp("wrong_stratgy"))
+	assert.Error(t, err)
+
+	err = FindOrCreatePartitionGroup(ec2c, "bad_prefix", to.Strp("i/i/groupName"), to.Int64p(10), to.Strp("wrong_stratgy"))
 	assert.Error(t, err)
 }

--- a/aws/pg/placement_group_test.go
+++ b/aws/pg/placement_group_test.go
@@ -1,0 +1,27 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coinbase/odin/aws/mocks"
+	"github.com/coinbase/step/utils/to"
+)
+
+func Test_FindOrCreatePartitionGroup(t *testing.T) {
+	//func Find(ec2Client aws.EC2API, name_tags_or_ids []*string) ([]*Subnet, error) {
+	ec2c := &mocks.EC2Client{}
+
+	// This will creates a placement group
+	err := FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("cluster"))
+	assert.NoError(t, err)
+
+	// Finds the already created group
+	err = FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("cluster"))
+	assert.NoError(t, err)
+
+	// This will error because the strategy is incorrect
+	err = FindOrCreatePartitionGroup(ec2c, to.Strp("groupName"), to.Int64p(10), to.Strp("wrong_stratgy"))
+	assert.Error(t, err)
+}

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -131,7 +131,7 @@ func MockRelease(t *testing.T) *Release {
         "target_groups": ["web-elb-target"],
         "profile" : "web-profile",
         "ebs_volume_size": 120,
-        "placement_group_name": "moonbase-partition",
+        "placement_group_name": "odin/project/config/moonbase-partition",
         "placement_group_partition_count": 5,
         "placement_group_strategy": "partition",
         "tags": {

--- a/deployer/models/mocks.go
+++ b/deployer/models/mocks.go
@@ -131,6 +131,9 @@ func MockRelease(t *testing.T) *Release {
         "target_groups": ["web-elb-target"],
         "profile" : "web-profile",
         "ebs_volume_size": 120,
+        "placement_group_name": "moonbase-partition",
+        "placement_group_partition_count": 5,
+        "placement_group_strategy": "partition",
         "tags": {
           "custom": "tag"
         },

--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coinbase/odin/aws/elb"
 	"github.com/coinbase/odin/aws/iam"
 	"github.com/coinbase/odin/aws/lc"
+	"github.com/coinbase/odin/aws/pg"
 	"github.com/coinbase/odin/aws/sg"
 	"github.com/coinbase/step/utils/is"
 	"github.com/coinbase/step/utils/to"
@@ -56,6 +57,11 @@ type Service struct {
 	EBSVolumeSize *int64  `json:"ebs_volume_size,omitempty"`
 	EBSVolumeType *string `json:"ebs_volume_type,omitempty"`
 	EBSDeviceName *string `json:"ebs_device_name,omitempty"`
+
+	// Placement Group
+	PlacementGroupName           *string `json:"placement_group_name,omitempty"`
+	PlacementGroupPartitionCount *int64  `json:"placement_group_partition_count,omitempty"`
+	PlacementGroupStrategy       *string `json:"placement_group_strategy,omitempty"`
 
 	// Network
 	AssociatePublicIpAddress *bool `json:"associate_public_ip_address,omitempty"`
@@ -297,6 +303,29 @@ func (service *Service) ValidateAttributes() error {
 		return fmt.Errorf("Non Unique TargetGroups")
 	}
 
+	// if PlacementGroupName is not nil, then there must be a Strategy either cluster | spread | partition
+	// if the strategy is partition then there must be a partition count
+	if service.PlacementGroupName != nil {
+		if service.PlacementGroupStrategy == nil {
+			return fmt.Errorf("PlacementGroupStrategy must be defined with PlacementGroupName")
+		}
+
+		strat := *service.PlacementGroupStrategy
+
+		// must be one of cluster | spread | partition
+		if strat != "cluster" && strat != "spread" && strat != "partition" {
+			return fmt.Errorf("PlacementGroupStrategy must be one of 'cluster' or 'spread' or 'partition'")
+		}
+
+		if strat == "partition" && service.PlacementGroupPartitionCount == nil {
+			return fmt.Errorf("PlacementGroupPartitionCount must be defined if PlacementGroupName and strategy is 'partition'")
+		}
+
+		if strat != "partition" && service.PlacementGroupPartitionCount != nil {
+			return fmt.Errorf("PlacementGroupPartitionCount only valid for 'partition' strategy")
+		}
+	}
+
 	return nil
 }
 
@@ -323,6 +352,17 @@ func (service *Service) FetchResources(ec2 aws.EC2API, elbc aws.ELBAPI, albc aws
 	targetGroups, err := alb.FindAll(albc, service.TargetGroups)
 	if err != nil {
 		return nil, err
+	}
+
+	if service.PlacementGroupName != nil {
+		if err := pg.FindOrCreatePartitionGroup(
+			ec2,
+			service.PlacementGroupName,
+			service.PlacementGroupPartitionCount,
+			service.PlacementGroupStrategy,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	// FETCH IAM
@@ -394,6 +434,10 @@ func (service *Service) createInput() *asg.Input {
 
 	input.VPCZoneIdentifier = service.SubnetIds()
 	input.LifecycleHookSpecificationList = service.LifeCycleHookSpecs()
+
+	if service.PlacementGroupName != nil {
+		input.PlacementGroup = service.PlacementGroupName
+	}
 
 	for key, value := range service.Tags {
 		input.AddTag(key, value)

--- a/deployer/models/service.go
+++ b/deployer/models/service.go
@@ -303,6 +303,14 @@ func (service *Service) ValidateAttributes() error {
 		return fmt.Errorf("Non Unique TargetGroups")
 	}
 
+	if err := service.validatePlacementGroupAttributes(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (service *Service) validatePlacementGroupAttributes() error {
 	// if PlacementGroupName is not nil, then there must be a Strategy either cluster | spread | partition
 	// if the strategy is partition then there must be a partition count
 	if service.PlacementGroupName != nil {
@@ -357,6 +365,7 @@ func (service *Service) FetchResources(ec2 aws.EC2API, elbc aws.ELBAPI, albc aws
 	if service.PlacementGroupName != nil {
 		if err := pg.FindOrCreatePartitionGroup(
 			ec2,
+			fmt.Sprintf("odin/%s/%s", *service.ProjectName(), *service.ConfigName()), // only required if new placement group is created
 			service.PlacementGroupName,
 			service.PlacementGroupPartitionCount,
 			service.PlacementGroupStrategy,

--- a/deployer/models/service_test.go
+++ b/deployer/models/service_test.go
@@ -53,8 +53,9 @@ func Test_Service_PlacementgroupValidation(t *testing.T) {
 
 	// need only if partitionPartitionCount
 	service = Service{
-		PlacementGroupName:     to.Strp("asd"),
-		PlacementGroupStrategy: to.Strp("spread"),
+		PlacementGroupName:           to.Strp("asd"),
+		PlacementGroupStrategy:       to.Strp("spread"),
+		PlacementGroupPartitionCount: to.Int64p(10),
 	}
 
 	err = service.validatePlacementGroupAttributes()

--- a/deployer/models/service_test.go
+++ b/deployer/models/service_test.go
@@ -29,3 +29,46 @@ func Test_Service_CreateInput_HealthCheckGracePeriod(t *testing.T) {
 	input := service.createInput()
 	assert.Equal(t, *input.HealthCheckGracePeriod, int64(10))
 }
+
+func Test_Service_PlacementgroupValidation(t *testing.T) {
+	// bad strat
+	service := Service{
+		PlacementGroupName:     to.Strp("asd"),
+		PlacementGroupStrategy: to.Strp("asd"),
+	}
+
+	err := service.validatePlacementGroupAttributes()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "PlacementGroupStrategy")
+
+	// need PartitionCount
+	service = Service{
+		PlacementGroupName:     to.Strp("asd"),
+		PlacementGroupStrategy: to.Strp("partition"),
+	}
+
+	err = service.validatePlacementGroupAttributes()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "PlacementGroupPartitionCount")
+
+	// need only if partitionPartitionCount
+	service = Service{
+		PlacementGroupName:     to.Strp("asd"),
+		PlacementGroupStrategy: to.Strp("spread"),
+	}
+
+	err = service.validatePlacementGroupAttributes()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "PlacementGroupPartitionCount")
+
+	// need PartitionCount
+	service = Service{
+		PlacementGroupName:           to.Strp("asd"),
+		PlacementGroupStrategy:       to.Strp("partition"),
+		PlacementGroupPartitionCount: to.Int64p(10),
+	}
+
+	err = service.validatePlacementGroupAttributes()
+	assert.NoError(t, err)
+
+}


### PR DESCRIPTION
This feature will create/use placement groups for AutoScalingGroups. This PR: 
1. Creates the placement group if not yet created (if created validates the prefix is `odin/<project_name>/<config_name>`)
2.  If already existing checks the values provided are the same to make sure we know the values. (we don't do any kind of updating because might cause bad situations where two projects update the placemnet group causing lots of termed instances) 

There are many caveats to using placement groups when deploying, read about them https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster