### PR TITLE
[Fix] reset the desired capacity to remove the spread

### DIFF
--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -35,6 +35,8 @@ type ASGClient struct {
 
 	DescribeLoadBalancerTargetGroupsOutput *autoscaling.DescribeLoadBalancerTargetGroupsOutput
 	DescribeLoadBalancersOutput            *autoscaling.DescribeLoadBalancersOutput
+
+	SetDesiredCapacityLastInput *autoscaling.SetDesiredCapacityInput
 }
 
 func (m *ASGClient) init() {
@@ -244,4 +246,9 @@ func (m *ASGClient) DescribeLoadBalancers(input *autoscaling.DescribeLoadBalance
 		return m.DescribeLoadBalancersOutput, nil
 	}
 	return &autoscaling.DescribeLoadBalancersOutput{}, nil
+}
+
+func (m *ASGClient) SetDesiredCapacity(input *autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error) {
+	m.SetDesiredCapacityLastInput = input
+	return nil, nil
 }

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -186,6 +186,14 @@ func CleanUpSuccess(awsc aws.Clients) DeployHandler {
 			return nil, &errors.LockError{err.Error()}
 		}
 
+		if err := release.ResetDesiredCapacity(
+			awsc.ASGClient(release.AwsRegion, release.AwsAccountID, assumedRole),
+		); err != nil {
+			// We ignore this error as failing to reset the capacity should not cause a massive issue
+			// Log the error in case
+			fmt.Printf("IGNORED: %v \n", err)
+		}
+
 		release.RemoveHalt(awsc.S3Client(release.AwsRegion, nil, nil)) // Delete Halt
 
 		release.Success = to.Boolp(true) // Wait till the end to mark success

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -208,6 +208,25 @@ func (release *Release) SuccessfulTearDown(asgc aws.ASGAPI, cwc aws.CWAPI) error
 	return nil
 }
 
+// ResetDesiredCapacity resets the ASGs to the desired capacity that would exist without `spread`
+// This is due to a situation where each successive deploy would ratchet up the desired capacity
+func (release *Release) ResetDesiredCapacity(asgc aws.ASGAPI) error {
+	errors := []error{}
+	for _, service := range release.Services {
+		err := service.SetDesiredCapacity(asgc)
+		// Continue to set capacities even when error is detected
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("Error ResetDesiredCapacity: %v", errors)
+	}
+
+	return nil
+}
+
 // Failure
 
 // DetachForFailure detach new ASGs


### PR DESCRIPTION
This PR will reset the desired capacity of the Autoscaling groups back to the value without spread. This is because sometimes the value of the desired capacity can ratchet up over many deploys and 1) cost more 2) make deploys take longer 3) cause other errors related to resource exhaustion. 

The main danger with this PR is that if there is an autoscaling event on either the new or old ASG during the deploy this will not take that into account when resetting the instance count.

This has been tested in development.