### PR TITLE
[Feature] Detach Strategies

### DIFF
--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -37,6 +37,7 @@ type ASGClient struct {
 	DescribeLoadBalancersOutput            *autoscaling.DescribeLoadBalancersOutput
 
 	SetDesiredCapacityLastInput *autoscaling.SetDesiredCapacityInput
+	DetachLoadBalancersError    error
 }
 
 func (m *ASGClient) init() {
@@ -227,7 +228,7 @@ func (m *ASGClient) PutScalingPolicy(input *autoscaling.PutScalingPolicyInput) (
 }
 
 func (m *ASGClient) DetachLoadBalancers(input *autoscaling.DetachLoadBalancersInput) (*autoscaling.DetachLoadBalancersOutput, error) {
-	return nil, nil
+	return nil, m.DetachLoadBalancersError
 }
 
 func (m *ASGClient) DetachLoadBalancerTargetGroups(input *autoscaling.DetachLoadBalancerTargetGroupsInput) (*autoscaling.DetachLoadBalancerTargetGroupsOutput, error) {

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/coinbase/odin/aws"
+	"github.com/coinbase/odin/aws/mocks"
 	"github.com/coinbase/odin/deployer/models"
 	"github.com/coinbase/step/machine"
 	"github.com/coinbase/step/utils/to"
@@ -12,6 +13,12 @@ import (
 
 func assertSuccessfulExecution(t *testing.T, release *models.Release) {
 	awsc := models.MockAwsClients(release)
+
+	assertSuccessfulExecutionWithAWS(t, release, awsc)
+}
+
+func assertSuccessfulExecutionWithAWS(t *testing.T, release *models.Release, awsc *mocks.MockClients) {
+
 	stateMachine := createTestStateMachine(t, awsc)
 
 	previousRelease := models.MockRelease(t)

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -34,6 +34,9 @@ type Release struct {
 	// AWS Service is Downloaded
 	Services map[string]*Service `json:"services,omitempty"` // Downloaded From S3
 
+	// DetachStrategy can be "Detach"(default) | "SkipDetach" || "SkipDetachCheck"
+	DetachStrategy *string `json:"detach_strategy,omitempty"`
+
 	// DEPRECATED: leave for backwards compatability
 	WaitForDetach *int `json:"wait_for_detach,omitempty"`
 }
@@ -95,6 +98,10 @@ func (release *Release) SetDefaults() {
 
 	if release.LifeCycleHooks == nil {
 		release.LifeCycleHooks = map[string]*LifeCycleHook{}
+	}
+
+	if release.DetachStrategy == nil {
+		release.DetachStrategy = to.Strp("Detach")
 	}
 
 	for name, lc := range release.LifeCycleHooks {

--- a/deployer/models/release.go
+++ b/deployer/models/release.go
@@ -141,6 +141,17 @@ func (release *Release) Validate(s3c aws.S3API) error {
 		return fmt.Errorf("%v Rule of Thumb (5/WaitForHealthy) * Timeout < 10k", release.ErrorPrefix())
 	}
 
+	// DetachStrategy
+	if release.DetachStrategy == nil {
+		return fmt.Errorf("%v %v", release.ErrorPrefix(), "DetachStrategy must be provided")
+	}
+	switch *release.DetachStrategy {
+	case "Detach", "SkipDetach", "SkipDetachCheck":
+		//skip
+	default:
+		return fmt.Errorf("%v %v", release.ErrorPrefix(), "DetachStrategy must be either 'Detach', 'SkipDetach', 'SkipDetachCheck'")
+	}
+
 	if release.Image == nil {
 		return fmt.Errorf("%v %v", release.ErrorPrefix(), "AMI image must be provided")
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/scripts/graph
+++ b/scripts/graph
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+step dot -states "$(go run odin.go json)" | dot -Tpng -o assets/sm.png; open assets/sm.png


### PR DESCRIPTION
This will let a user select how Odin detaches its instances from ELBs. In this PR we default to what we typically do, but you could either:

1. Skip detaching all together
2. Call Detach, but skip checking for when detach finishes.

The first is what the old behaviour of Odin was, but can be unsafe with lots of traffic. The second can be useful if we want to start bringing down the instances while it is detaching. Which is useful for long lived connections.


