### PR TITLE
[Fix] fixing small numbers of ramp up value

### DIFF
--- a/deployer/models/strategy_test.go
+++ b/deployer/models/strategy_test.go
@@ -219,6 +219,10 @@ func Test_Strategy_25StepRolloutNoCanary_Rate(t *testing.T) {
 	assert.EqualValues(t, 1, fastRolloutRate(0, 2))
 	assert.EqualValues(t, 1, fastRolloutRate(0, 4))
 
+	// Dont get stuck on low numbers
+	assert.EqualValues(t, 1, fastRolloutRate(1, 1))
+	assert.EqualValues(t, 2, fastRolloutRate(1, 2))
+
 	// Never return greater than the baseAmount
 	assert.EqualValues(t, 5, fastRolloutRate(100, 5))
 	assert.EqualValues(t, 10, fastRolloutRate(10, 10))


### PR DESCRIPTION
the /4 in the method should always return greater than 0 otherwise services with less than 4 instances will get stuck.