### PR TITLE
Speed up DetachForFailure step

### DIFF
--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -193,8 +193,8 @@ func StateMachine() (*machine.StateMachine, error) {
         "Retry": [{
           "Comment": "Retry on Detach Error",
           "ErrorEquals": ["DetachError"],
-          "MaxAttempts": 30,
-          "IntervalSeconds": 30,
+          "MaxAttempts": 6,
+          "IntervalSeconds": 10,
           "BackoffRate": 1.0
          },{
           "Comment": "Keep trying to Clean",


### PR DESCRIPTION
We're seeing long delays in deploy halting, up to 7 minutes. This PR reduces the retry count / period to limit the detach wait time to 1 minute.