### PR TITLE
Fix DetachError issue

### DIFF
--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -191,12 +191,6 @@ func StateMachine() (*machine.StateMachine, error) {
         "Comment": "Detach Old ASGs",
         "Next": "WaitDetachForFailure",
         "Retry": [{
-          "Comment": "Retry on Detach Error",
-          "ErrorEquals": ["DetachError"],
-          "MaxAttempts": 6,
-          "IntervalSeconds": 10,
-          "BackoffRate": 1.0
-         },{
           "Comment": "Keep trying to Clean",
           "ErrorEquals": ["States.ALL"],
           "MaxAttempts": 3,
@@ -212,7 +206,7 @@ func StateMachine() (*machine.StateMachine, error) {
       "WaitDetachForFailure": {
         "Comment": "Give detach a little time to do what it does",
         "Type": "Wait",
-        "Seconds" : 5,
+        "Seconds" : 60,
         "Next": "CleanUpFailure"
       },
       "CleanUpFailure": {

--- a/deployer/models/release_resources.go
+++ b/deployer/models/release_resources.go
@@ -276,7 +276,17 @@ func (release *Release) DetachForFailure(asgc aws.ASGAPI) error {
 	}
 
 	if err := release.DetachAllASGs(asgc, asgs); err != nil {
-		return err
+		switch err.(type) {
+		case DetachError:
+			// Detached isn't finished yet. We don't care to wait for it to finish in this DetachForFailure state,
+			// so we'll just continue.
+			// Don't set this error on the release object as to not overwrite the other error.
+			// We may need to do something for other errors here. They'd overwrite as well, but
+			// are unexpected errors that we don't want to just drop.
+			return nil
+		default:
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
After recent changes to retry less times on DetachForFailure, this error was being hit from time to time and would overwrite the error object on the release which was responsible for sending the deploy into the failure state in the first place. As we don't care to wait for detach to finish here, we increase the wait after this to 60s. Other errors in DetachForFailure would still behave the same way, which seems like what we'd want here as they are not expected like this one.
