### PR TITLE
Add MaxSize to Odin's ASG struct

### DIFF
--- a/aws/asg/asg.go
+++ b/aws/asg/asg.go
@@ -20,6 +20,7 @@ type ASG struct {
 	ReleaseIdTag   *string
 
 	MinSize         *int64
+	MaxSize         *int64
 	DesiredCapacity *int64
 
 	AutoScalingGroupName    *string
@@ -85,6 +86,7 @@ func newASG(group *autoscaling.Group) *ASG {
 
 		DesiredCapacity: group.DesiredCapacity,
 		MinSize:         group.MinSize,
+		MaxSize:         group.MaxSize,
 
 		instances: group.Instances,
 	}

--- a/aws/mocks/mock_asg.go
+++ b/aws/mocks/mock_asg.go
@@ -63,6 +63,7 @@ func MakeMockASG(name string, projetName string, configName string, serviceName 
 		TargetGroupARNs:      []*string{to.Strp("tg")},
 
 		MinSize:         to.Int64p(1),
+		MaxSize:         to.Int64p(3),
 		DesiredCapacity: to.Int64p(1),
 		Tags: []*autoscaling.TagDescription{
 			&autoscaling.TagDescription{Key: to.Strp("ProjectName"), Value: to.Strp(projetName)},


### PR DESCRIPTION
Although Odin does not require an Auto Scaling Group's MaxSize, third party code that imports Odin's modules may need it.